### PR TITLE
Remove calstat from BuildSoGiveApp dependencies

### DIFF
--- a/builder/BuildSoGiveApp.java
+++ b/builder/BuildSoGiveApp.java
@@ -26,7 +26,6 @@ public class BuildSoGiveApp extends BuildWinterwellProject {
 		mdt.addDependency("org.mockito:mockito-core:3.3.3");
 		deps.add(mdt);
 		
-		deps.add(new WWDependencyTask("calstat", "com.winterwell.calstat.BuildCalstat"));		
 		return deps;
 	}
 


### PR DESCRIPTION
When calstat is included in dependencies, `java -jar bob-all.jar` fails for me with

```
#bob.WWDependencyTask Running WWDependencyTask[projectName=calstat] at Sat, 16 May 2020 19:02:04...                                                                                                                             
#bob.WWDependencyTask ...exiting WWDependencyTask[projectName=calstat]                            
#bob.BuildSoGiveApp ...exiting BuildSoGiveApp[projectName=sogive]                                                                                                                                                               
Exception in thread "main" java.lang.NullPointerException                                     
        at com.winterwell.bob.tasks.EclipseClasspath.<init>(EclipseClasspath.java:67)                                                                                                                                           
        at com.winterwell.bob.wwjobs.BuildWinterwellProject.getDependencies(BuildWinterwellProject.java:71)
        at com.winterwell.bob.BuildTask.doDependencies(BuildTask.java:473)                                                                                                                                                      
        at com.winterwell.bob.BuildTask.run(BuildTask.java:337)                                         
        at com.winterwell.bob.BuildTask.doDependencies(BuildTask.java:477)                                                                                                                                                      
        at com.winterwell.bob.BuildTask.run(BuildTask.java:337)                         
        at com.winterwell.bob.Bob.build(Bob.java:474)                                                                                                                                                                           
        at com.winterwell.bob.Bob.main(Bob.java:346)
```

Removing calstat doesn't appear to prevent SoGiveApp from building or running.