### PR TITLE
Improve frontend installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,41 @@ Note: the sogive-app repo contains some symlinks to folders in the wwappbase.js 
 
        ./watch.sh
 
-7. Setup a local web-server (e.g. nginx or http-server) serving the sogive-app/web folder
+7. Setup a local web-server (e.g. nginx or http-server) serving the sogive-app/web folder. For example, for nginx:
+  
+	   sudo apt install nginx
+	   cd /etc/nginx/sites-enabled
+	   sudo nano ../sites-available/local.sogive.org
+    
+     - paste the following into the file, and replace the `root` path:
+	```
+	server {
+		listen   80; ## listen for ipv4; this line is default and implied
+		root [path to sogive-app directory e.g. /home/your_username/winterwell/sogive-app]/web;
+		index index.html;
+		server_name local.sogive.org;
+		location / {
+				try_files $uri $uri/ @backend;
+				add_header 'Access-Control-Allow-Origin' "$http_origin";
+				add_header 'Access-Control-Allow-Credentials' 'true';
+		}
+		location @backend {
+				proxy_pass              http://localhost:8282;
+				proxy_set_header        X-Real-IP $remote_addr;
+				proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+				proxy_set_header        Host $http_host;
+		}
+	}
+	```
+
+     - symlink the file and start nginx:
+
+           sudo ln -s ../sites-available/local.sogive.org .
+           sudo service nginx restart
 
 8. Optional: Modify your /etc/hosts to have `127.0.0.1 local.sogive.org`
 
-9. Test: You should be able to view your local SoGive from a browser. It may fail to connect with a backend server, and emit an error. But you can check the js compilation is working.
+9. Test: You should be able to view your local SoGive from a browser at http://local.sogive.org. It may fail to connect with a backend server, and emit an error. But you can check the js compilation is working.
 
 10. If you got a connection error - Edit src/js/plumbing/ServerIO.js and uncomment the line:
 	`ServerIO.APIBASE = 'https://test.sogive.org';`

--- a/README.md
+++ b/README.md
@@ -14,41 +14,42 @@ These instructions assume Linux.
 
 2. Make a folder to hold this repo + its siblings. We'll name this winterwell, after the company that wrote the original code.
 
-	cd ~
-	mkdir winterwell
-	cd winterwell
+       cd ~
+       mkdir winterwell
+       cd winterwell
 
 3. Clone this repo and its siblings
 
-	git clone git@github.com:winterstein/sogive-app.git
-	git clone git@github.com:winterstein/wwappbase.js.git
+       git clone git@github.com:winterstein/sogive-app.git
+       git clone git@github.com:winterstein/wwappbase.js.git
 
 Note: the sogive-app repo contains some symlinks to folders in the wwappbase.js repo.
 
 4. Install npm packages
 
-	cd sogive-app
-	npm i
+       cd sogive-app
+       npm i
 
-4. Compile the css
+5. Compile the css (must be run from bash, not zsh)
 	
-	./convert-less.sh
+       sudo apt install node-less
+       ./convert-less.sh
 
-5. Compile the js (and watch for edits)
+6. Compile the js (and watch for edits)
 
-	./watch.sh
+       ./watch.sh
 
-6. Setup a local web-server (e.g. nginx or http-server) serving the sogive-app/web folder
+7. Setup a local web-server (e.g. nginx or http-server) serving the sogive-app/web folder
 
-7. Optional: Modify your /etc/hosts to have `127.0.0.1 local.sogive.org`
+8. Optional: Modify your /etc/hosts to have `127.0.0.1 local.sogive.org`
 
-8. Test: You should be able to view your local SoGive from a browser. It may fail to connect with a backend server, and emit an error. But you can check the js compilation is working.
+9. Test: You should be able to view your local SoGive from a browser. It may fail to connect with a backend server, and emit an error. But you can check the js compilation is working.
 
-9. If you got a connection error - Edit src/js/plumbing/ServerIO.js and uncomment the line:
+10. If you got a connection error - Edit src/js/plumbing/ServerIO.js and uncomment the line:
 	`ServerIO.APIBASE = 'https://test.sogive.org';`
 Your local SoGive should now connect to a test server, which has some data.
 
-10. Celebrate as you see best. Ask Sanjay if you want a recommendation for
+11. Celebrate as you see best. Ask Sanjay if you want a recommendation for
 a high impact celebration.
 
 
@@ -66,8 +67,8 @@ Though we will switch to version 7 soon.
 
 4. Use Bob to fetch dependency jars:
 
-	cd sogive-app
-	java -jar bob-all.jar
+       cd sogive-app
+       java -jar bob-all.jar
 
 5. Start ElasticSearch, with xpack security disabled (why??). 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: the sogive-app repo contains some symlinks to folders in the wwappbase.js 
 5. Compile the css (must be run from bash, not zsh)
 	
        sudo apt install node-less
-       ./convert-less.sh
+       ./convert.less.sh
 
 6. Compile the js (and watch for edits)
 


### PR DESCRIPTION
- I found ./convert.less.sh only worked from bash and if I installed node-less first, hence adding this to step 5.

- Tidied up formatting of command line instructions (they weren't previously formatted as code) and numbers in the markdown (removed duplicate).