### PR TITLE
[Puppeteer tests] Make tests filterable by name

### DIFF
--- a/runtest.js
+++ b/runtest.js
@@ -19,6 +19,9 @@ Options
 	--test <filename> Use to filter by test. This matches on test file names.
 	--chrome Run tests in Chrome instead of Puppeteer's default browser (Chromium)
 
+	-- -t <testname> Use to filter by test name. Must be the last option in the command.
+	                 (Subsequent options will be ignored.)
+
 Tests are defined in: src/puppeteer-tests/__tests__
 (this is where jest-puppeteer looks)
 	`);
@@ -47,6 +50,11 @@ let testPath = '';
  * If true, switch to single-threaded mode
  */
 let runInBand = '';
+/**
+ * Filters tests by name (within testPath, if set). e.g.
+  * `node runtest.js --test donate -- -t 'Logged-out'`
+*/
+let testFilter = '';
 
 Object.entries(yargv).forEach(([key, value]) => {
 	if (key === 'test') { testPath = value; }
@@ -57,6 +65,9 @@ Object.entries(yargv).forEach(([key, value]) => {
 			const bool = config[key];
 			config[key] = !bool;
 		} else config[key] = value;
+	}
+	if (key === '_' && value[0] === '-t') {
+		testFilter = `-- -t ${value[1]}`;
 	}
 });
 
@@ -70,4 +81,4 @@ process.env.FORCE_COLOR = true;
 process.argv = argv;
 
 // Execute Jest. Specific target optional.
-shell.exec(`npm run test ${testPath} ${runInBand}`);
+shell.exec(`npm run test ${testPath} ${runInBand} ${testFilter}`);


### PR DESCRIPTION
- Previously, you could just filter by test file name using the
  `-- test` option.

- Now you can also filter by test name, to run a subset of tests
within a file.

- Note, instructions for using this flag were already added to the
README (I didn't notice this didn't work with the runtest.js script at
the time).

- The `-- -t` syntax is because this is how it works if you run tests
via the `npm run test` method, and I think it makes sense to keep them
consistent.