### PR TITLE
[Puppeteer tests] Fix typo in prod server config

### DIFF
--- a/src/puppeteer-tests/testConfig.js
+++ b/src/puppeteer-tests/testConfig.js
@@ -3,7 +3,7 @@
 const targetServers = {
 	local: 'http://local.sogive.org',
 	test: 'https://test.sogive.org',
-	prod: 'https://sogive.org'
+	prod: 'https://app.sogive.org'
 };
 
 


### PR DESCRIPTION
- Now tests can be run against the real site using `--site prod` flag