### PR TITLE
Created ImportSoGiveEditorials script to update recommendations

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,6 +23,7 @@
 	<classpathentry kind="lib" path="dependencies/stripe-java.jar" sourcepath="dependencies/stripe-java-17.8.0.zip"/>
 	<classpathentry kind="lib" path="dependencies/lombok.jar"/>
 	<classpathentry kind="lib" path="dependencies/mockito-core.jar"/>
+	<classpathentry kind="lib" path="dependencies/opencsv.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/builder/BuildSoGiveApp.java
+++ b/builder/BuildSoGiveApp.java
@@ -24,6 +24,7 @@ public class BuildSoGiveApp extends BuildWinterwellProject {
 		mdt.addDependency("com.stripe:stripe-java:16.5.0");
 		mdt.addDependency("org.projectlombok:lombok:1.18.12");
 		mdt.addDependency("org.mockito:mockito-core:3.3.3");
+		mdt.addDependency("com.opencsv:opencsv:5.2");
 		deps.add(mdt);
 		
 		return deps;

--- a/src/java/org/sogive/data/loader/CharityMatcher.java
+++ b/src/java/org/sogive/data/loader/CharityMatcher.java
@@ -48,4 +48,13 @@ public class CharityMatcher {
 		return od;
 	}
 
+	public ObjectDistribution<NGO> matchByIdOnly(NGO ngo) {
+		ObjectDistribution<NGO> od = new ObjectDistribution<>();
+		List<NGO> charity = DBSoGive.getCharityById(ngo);
+		if (charity != null && ! charity.isEmpty()) {
+			od.train(charity);
+		}
+		return od;
+	}
+
 }

--- a/src/java/org/sogive/data/loader/ImportSoGiveEditorials.java
+++ b/src/java/org/sogive/data/loader/ImportSoGiveEditorials.java
@@ -1,0 +1,93 @@
+package org.sogive.data.loader;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import org.sogive.data.charity.NGO;
+import org.sogive.data.charity.SoGiveConfig;
+import org.sogive.server.SoGiveServer;
+
+import com.opencsv.CSVReader;
+import com.winterwell.data.KStatus;
+import com.winterwell.es.ESPath;
+import com.winterwell.maths.stats.distributions.discrete.ObjectDistribution;
+import com.winterwell.utils.Dep;
+import com.winterwell.utils.Utils;
+import com.winterwell.web.ajax.JThing;
+import com.winterwell.web.app.AppUtils;
+
+/**
+ * Updates the editorial field for charities which already exist in the SoGive database, from
+ * data in CSV format: charity_id, charity_editorial (no headers)
+ * 
+ * @author anita
+ */
+public class ImportSoGiveEditorials {
+
+	public static void main(String[] args) {
+		if (args.length != 1) {
+			System.err.println(
+					"Must provide exactly one argument, specifying absolute file path of CSV");
+			return;
+		}
+		new SoGiveServer().init();
+
+		String filePath = args[0];
+		System.out.println(String.format("Importing data from file: %s", filePath));
+		new ImportSoGiveEditorials().run(filePath);
+		System.out.println("Finished importing data.");
+	}
+
+	private volatile boolean running;
+
+	public synchronized void run(String filePath) {
+		running = true;
+		CSVReader reader = null;
+		try {
+			reader = new CSVReader(new FileReader(filePath));
+		} catch (FileNotFoundException e) {
+			System.err.println(String.format(
+					"Error finding CSV at path '%s': %s", filePath, e.getMessage()));
+			e.printStackTrace();
+		}
+		CharityMatcher charityMatcher = new CharityMatcher();
+		for (String[] row : reader) {
+			String ourId = row[0].trim();
+			NGO ngo = new NGO(ourId);
+
+			ObjectDistribution<NGO> matches = charityMatcher.matchByIdOnly(ngo);
+			if (matches.isEmpty()) {
+				continue;
+			}
+			String editorial = row[1];
+			doUpdateCharity(ngo, editorial);
+		}
+
+		running = false;
+	}
+
+	private static void doUpdateCharity(NGO ngo, String editorial) {
+		ngo.put("recommendation", editorial);
+
+		SoGiveConfig config;
+		if (Dep.has(SoGiveConfig.class)) {
+			config = Dep.get(SoGiveConfig.class);	
+		} else {
+			config = AppUtils.getConfig("sogive", new SoGiveConfig(), null);
+		}
+
+		String ourId = ngo.getId();
+		assert !Utils.isBlank(ourId);
+
+		ESPath draftPath = config.getPath(null, NGO.class, ourId, KStatus.DRAFT);
+		ESPath publishPath = config.getPath(null, NGO.class, ourId, KStatus.PUBLISHED);
+		
+		JThing<NGO> item = new JThing<NGO>().setJava(ngo);
+		AppUtils.doSaveEdit(draftPath, item, null);
+		AppUtils.doPublish(item, draftPath, publishPath);
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+	
+}


### PR DESCRIPTION
- Copied code in ImportOSCRData for the database interactions. 

- Decided to use opencsv 3rd party csv parsing library, as more forgiving than the apache csv library.

- Input file path is taken as a command line argument (can be supplied to Eclipse via Run Configurations).

- Input file can be generated by running the 'copyDataFromGoogleDoc' Macro in the SoGive Editorials Google Sheet at https://docs.google.com/spreadsheets/d/1qijqaV2AZM6dqI0Kfc3oFkcuDb6_TXKd9tlcbh5c_vE/edit#gid=0 , and then File > Download > Comma-separated values (csv).

- Script will only overwrite the 'recommendation' field, and only for existing charities in the database (matched by charity_id).