### PR TITLE
Wrap serverSafetyCheck in beforeAll async await

### DIFF
--- a/src/puppeteer-tests/__tests__/create-event.test.js
+++ b/src/puppeteer-tests/__tests__/create-event.test.js
@@ -21,7 +21,9 @@ const eventData = {
 
 describe("Create-Event-Tests", () => {
 	
-	serverSafetyCheck(page, url);
+	beforeAll(async() => {
+		await serverSafetyCheck(page, url);
+	});
 
 	const longName = "supercalifragilisticexpialidocious";
 	let id = '';

--- a/src/puppeteer-tests/__tests__/donate-to-charity.test.js
+++ b/src/puppeteer-tests/__tests__/donate-to-charity.test.js
@@ -21,7 +21,9 @@ let url = `${baseSite}`;
 
 describe("!!broken Charity donation tests", () => {
 	
-	serverSafetyCheck(page, url);
+	beforeAll(async() => {
+		await serverSafetyCheck(page, url);
+	});
 
 	// nobbled TODO fix
 	test("!! tests OFF", async () => {

--- a/src/puppeteer-tests/__tests__/editor.test.js
+++ b/src/puppeteer-tests/__tests__/editor.test.js
@@ -22,7 +22,9 @@ jest.setTimeout(30000);
 
 describe('Edit organisation tests', () => {
 	
-	serverSafetyCheck(page, url);
+	beforeAll(async() => {
+		await serverSafetyCheck(page, url);
+	});
 
 	test('Edit and publish field', async () => {
 		// Increase from default (800*600) as workaround for issue where off-screen elements added to DOM after

--- a/src/puppeteer-tests/__tests__/fundraiser.test.js
+++ b/src/puppeteer-tests/__tests__/fundraiser.test.js
@@ -47,7 +47,9 @@ const fundraiserIdClip = () => {
 
 describe("!!broken Fundraiser tests", () => {
 	
-	serverSafetyCheck(page, url);
+	beforeAll(async() => {
+		await serverSafetyCheck(page, url);
+	});
 
 	// nobbled TODO fix
 	test("!! tests OFF", async () => {

--- a/src/puppeteer-tests/__tests__/sogive-api.test.js
+++ b/src/puppeteer-tests/__tests__/sogive-api.test.js
@@ -4,7 +4,9 @@ const {getConfig, doLogin, fetch, serverSafetyCheck} = require('../test-base/Uti
 const server = targetServers[getConfig().site];
 
 describe("API-Tests", () => {
-	serverSafetyCheck(page, server);
+	beforeAll(async() => {
+		await serverSafetyCheck(page, url);
+	});
 
 	// Journey: requesting a list of charities
 	// Result: at least one charity


### PR DESCRIPTION
Without this I was getting the following errors when running some tests in headless mode:
```
net::ERR_ABORTED at http://local.sogive.org
Error: Execution context was destroyed, most likely because of a navigation.
Error: Navigation failed because browser has disconnected!
```
..I think because the page navigation in the first test was occurring before this check had completed. (Whereas headless mode (or the setViewPort in editor tests) slowed it down enough this check completed.)

Adding the beforeAll async await sorted it out.

Checked that when ServerIO.APIBASE is set to prod the check still successfully aborts before any tests are run.
