### PR TITLE
WIP: Upload editorials tool

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -18,15 +18,16 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="lib" path="dependencies/gson.jar"/>
-	<classpathentry kind="lib" path="dependencies/stripe-java.jar" sourcepath="dependencies/stripe-java-17.8.0.zip"/>
-	<classpathentry kind="lib" path="dependencies/lombok.jar"/>
-	<classpathentry kind="lib" path="dependencies/mockito-core.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="lib" path="dependencies/gson.jar"/>
+	<classpathentry kind="lib" path="dependencies/stripe-java.jar" sourcepath="dependencies/stripe-java-17.8.0.zip"/>
+	<classpathentry kind="lib" path="dependencies/lombok.jar"/>
+	<classpathentry kind="lib" path="dependencies/mockito-core.jar"/>
+	<classpathentry kind="lib" path="dependencies/jsoup.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/builder/BuildSoGiveApp.java
+++ b/builder/BuildSoGiveApp.java
@@ -23,6 +23,7 @@ public class BuildSoGiveApp extends BuildWinterwellProject {
 		mdt.addDependency("com.stripe:stripe-java:16.5.0");
 		mdt.addDependency("org.projectlombok:lombok:1.18.12");
 		mdt.addDependency("org.mockito:mockito-core:3.3.3");
+		mdt.addDependency("org.jsoup:jsoup:1.13.1");
 		deps.add(mdt);
 		
 		return deps;

--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -4,4 +4,9 @@ import org.sogive.data.charity.NGO;
 
 public interface DatabaseWriter {
     void upsertCharityRecord(NGO ngo);
+
+    /**
+     * Checks if this charity is published in the database.
+     */
+    boolean contains(String charityId);
 }

--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -1,0 +1,7 @@
+package org.sogive.data.loader;
+
+import org.sogive.data.charity.NGO;
+
+public interface DatabaseWriter {
+    void upsertCharityRecord(NGO ngo);
+}

--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -2,6 +2,11 @@ package org.sogive.data.loader;
 
 import org.sogive.data.charity.NGO;
 
+/**
+ * 
+ * @author Anita
+ *
+ */
 public interface DatabaseWriter {
     void upsertCharityRecord(NGO ngo);
 

--- a/src/java/org/sogive/data/loader/Editorial.java
+++ b/src/java/org/sogive/data/loader/Editorial.java
@@ -34,4 +34,11 @@ public class Editorial {
     public int hashCode() {
         return Objects.hash(charityId, editorialParagraphs);
     }
+
+	@Override
+	public String toString() {
+		return "Editorial[charityId=" + charityId + ", editorialParagraphs=" + editorialParagraphs + "]";
+	}
+    
+    
 }

--- a/src/java/org/sogive/data/loader/Editorial.java
+++ b/src/java/org/sogive/data/loader/Editorial.java
@@ -1,0 +1,37 @@
+package org.sogive.data.loader;
+
+import java.util.List;
+import java.util.Objects;
+
+public class Editorial {
+
+    private final String charityId;
+    private final List<String> editorialParagraphs;
+
+    public Editorial(String charityId, List<String> editorialParagraphs) {
+        this.charityId = charityId;
+        this.editorialParagraphs = editorialParagraphs;
+    }
+
+    public String getCharityId() {
+        return charityId;
+    }
+
+    public String getEditorialText() {
+        return String.join("\n\n", editorialParagraphs);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Editorial editorial1 = (Editorial) o;
+        return Objects.equals(charityId, editorial1.charityId) &&
+                Objects.equals(editorialParagraphs, editorial1.editorialParagraphs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(charityId, editorialParagraphs);
+    }
+}

--- a/src/java/org/sogive/data/loader/Editorials.java
+++ b/src/java/org/sogive/data/loader/Editorials.java
@@ -1,0 +1,30 @@
+package org.sogive.data.loader;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class Editorials implements Iterable<Editorial> {
+    private final Collection<Editorial> charityEditorials;
+
+    public Editorials(Collection<Editorial> charityEditorials) {
+        this.charityEditorials = charityEditorials;
+    }
+
+    public Editorials(Editorial... charityEditorials) {
+        this.charityEditorials = Arrays.asList(charityEditorials.clone());
+    }
+
+    @Override
+    public Iterator<Editorial> iterator() {
+        return charityEditorials.iterator();
+    }
+
+    public String getEditorial(String charityId) {
+        return charityEditorials.stream()
+                .filter(editorial -> editorial.getCharityId().equals(charityId))
+                .findFirst()
+                .map(Editorial::getEditorialText)
+                .orElse(null);
+    }
+}

--- a/src/java/org/sogive/data/loader/EditorialsFetcher.java
+++ b/src/java/org/sogive/data/loader/EditorialsFetcher.java
@@ -1,0 +1,47 @@
+package org.sogive.data.loader;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.winterwell.utils.log.Log;
+
+import java.io.IOException;
+import java.util.*;
+
+public class EditorialsFetcher {
+    private final JsoupDocumentFetcher documentFetcher;
+
+    public EditorialsFetcher(JsoupDocumentFetcher documentFetcher) {
+        this.documentFetcher = documentFetcher;
+    }
+
+    public Editorials getEditorials(String publishedGoogleDocsUrl) throws IOException {
+        Document editorialsDocument = documentFetcher.fetchDocument(publishedGoogleDocsUrl);
+        return parseFromDocument(editorialsDocument);
+    }
+
+    private static Editorials parseFromDocument(Document document) {
+        List<Editorial> charityEditorials = new ArrayList<>();
+        Elements header1s = document.getElementsByTag("h1");
+        for (Element h1 : header1s) {
+            String charityId = h1.text();
+            List<String> editorialParagraphs = new ArrayList<>();
+
+            Element paragraphElement = h1.nextElementSibling();
+            assert paragraphElement.tagName().equals("p");
+            editorialParagraphs.add(paragraphElement.text());
+
+            Element nextElement = paragraphElement.nextElementSibling();
+            while (nextElement != null && nextElement.tagName().equals("p")) {
+                String paragraphText = nextElement.text();
+                if (!paragraphText.isEmpty()) {
+                    editorialParagraphs.add(paragraphText);
+                }
+                nextElement = nextElement.nextElementSibling();
+            }
+            charityEditorials.add(new Editorial(charityId, editorialParagraphs));
+        }
+        return new Editorials(charityEditorials);
+    }
+}

--- a/src/java/org/sogive/data/loader/EditorialsFetcher.java
+++ b/src/java/org/sogive/data/loader/EditorialsFetcher.java
@@ -28,12 +28,11 @@ public class EditorialsFetcher {
             String charityId = h1.text();
             List<String> editorialParagraphs = new ArrayList<>();
 
-            Element paragraphElement = h1.nextElementSibling();
-            assert paragraphElement.tagName().equals("p");
-            editorialParagraphs.add(paragraphElement.text());
+            Element firstParagraphElement = h1.nextElementSibling();
+            editorialParagraphs.add(firstParagraphElement.text());
 
-            Element nextElement = paragraphElement.nextElementSibling();
-            while (nextElement != null && nextElement.tagName().equals("p")) {
+            Element nextElement = firstParagraphElement.nextElementSibling();
+            while (nextElement != null && !nextElement.tagName().equals("h1")) {
                 String paragraphText = nextElement.text();
                 if (!paragraphText.isEmpty()) {
                     editorialParagraphs.add(paragraphText);

--- a/src/java/org/sogive/data/loader/EditorialsFetcher.java
+++ b/src/java/org/sogive/data/loader/EditorialsFetcher.java
@@ -9,6 +9,15 @@ import com.winterwell.utils.log.Log;
 import java.io.IOException;
 import java.util.*;
 
+/**
+ * Fetch data from a Google Doc
+ * Assumes format:
+ * h1: charity ID
+ * editorial text (which can be across a few paragraphs)
+ * 
+ * @author Anita
+ *
+ */
 public class EditorialsFetcher {
     private final JsoupDocumentFetcher documentFetcher;
 
@@ -25,7 +34,7 @@ public class EditorialsFetcher {
         List<Editorial> charityEditorials = new ArrayList<>();
         Elements header1s = document.getElementsByTag("h1");
         for (Element h1 : header1s) {
-            String charityId = h1.text();
+            String charityId = h1.text().trim();
             List<String> editorialParagraphs = new ArrayList<>();
 
             Element firstParagraphElement = h1.nextElementSibling();

--- a/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
@@ -1,0 +1,19 @@
+package org.sogive.data.loader;
+
+import com.winterwell.data.KStatus;
+import com.winterwell.es.ESPath;
+import com.winterwell.es.IESRouter;
+import com.winterwell.utils.Dep;
+import com.winterwell.web.ajax.JThing;
+import com.winterwell.web.app.AppUtils;
+import org.sogive.data.charity.NGO;
+
+public class ElasticSearchDatabaseWriter implements DatabaseWriter {
+    @Override
+    public void upsertCharityRecord(NGO ngo) {
+        String charityId = ngo.getId();
+        ESPath draftPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.DRAFT);
+        ESPath pubPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.PUBLISHED);
+        AppUtils.doPublish(new JThing(ngo), draftPath, pubPath);
+    }
+}

--- a/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
@@ -7,6 +7,7 @@ import com.winterwell.utils.Dep;
 import com.winterwell.web.ajax.JThing;
 import com.winterwell.web.app.AppUtils;
 import org.sogive.data.charity.NGO;
+import org.sogive.data.charity.SoGiveConfig;
 
 public class ElasticSearchDatabaseWriter implements DatabaseWriter {
     @Override
@@ -15,5 +16,12 @@ public class ElasticSearchDatabaseWriter implements DatabaseWriter {
         ESPath draftPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.DRAFT);
         ESPath pubPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.PUBLISHED);
         AppUtils.doPublish(new JThing(ngo), draftPath, pubPath);
+    }
+
+    @Override
+    public boolean contains(String charityId) {
+        ESPath path = Dep.get(SoGiveConfig.class).getPath(null, NGO.class, charityId, KStatus.PUBLISHED);
+        NGO got = AppUtils.get(path, NGO.class);
+        return got != null;
     }
 }

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 
 /**
  * Imports editorials from a given published Google Doc url.
- * Such as ??url
+ * Such as https://docs.google.com/document/d/e/2PACX-1vTT_o-nxdI07X9CwybFQLEDEjbKvAvtEEbZPnf7XpKBMFSC4xpMa0rJYM7MwpvZqdb1O9GMuVtC7QAT/pub
  * 
  * @author anita
  *

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -2,7 +2,6 @@ package org.sogive.data.loader;
 
 import com.winterwell.utils.log.Log;
 import org.sogive.data.charity.NGO;
-import org.sogive.server.SoGiveServer;
 
 import java.io.IOException;
 
@@ -18,11 +17,11 @@ public class ImportEditorialsDataTask {
 	private volatile boolean running;
 
 	private final EditorialsFetcher editorialsFetcher;
-	private final DatabaseWriter databaseWriter;
+	private final DatabaseWriter database;
 
-	public ImportEditorialsDataTask(JsoupDocumentFetcher jsoupDocumentFetcher, DatabaseWriter databaseWriter) {
+	public ImportEditorialsDataTask(JsoupDocumentFetcher jsoupDocumentFetcher, DatabaseWriter database) {
 		editorialsFetcher = new EditorialsFetcher(jsoupDocumentFetcher);
-		this.databaseWriter = databaseWriter;
+		this.database = database;
 	}
 
 	public synchronized void run(String publishedGoogleDocsUrl) {
@@ -42,9 +41,13 @@ public class ImportEditorialsDataTask {
 	private void writeEditorials(Editorials editorials) {
 		for (Editorial editorial : editorials) {
 			String charityId = editorial.getCharityId();
+			// If it's not already in the charity database, we don't want to insert it.
+			if (!database.contains(charityId)) {
+				continue;
+			}
 			NGO ngo = new NGO(charityId);
 			ngo.put("recommendation", editorial.getEditorialText());
-			databaseWriter.upsertCharityRecord(ngo);
+			database.upsertCharityRecord(ngo);
 		}
 	}
 

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -1,0 +1,55 @@
+package org.sogive.data.loader;
+
+import com.winterwell.utils.log.Log;
+import org.sogive.data.charity.NGO;
+import org.sogive.server.SoGiveServer;
+
+import java.io.IOException;
+
+/**
+ * Imports editorials from a given published Google Doc url.
+ * @author anita
+ *
+ */
+public class ImportEditorialsDataTask {
+
+	private static final String TAG = ImportEditorialsDataTask.class.getSimpleName();
+
+	private volatile boolean running;
+
+	private final EditorialsFetcher editorialsFetcher;
+	private final DatabaseWriter databaseWriter;
+
+	public ImportEditorialsDataTask(JsoupDocumentFetcher jsoupDocumentFetcher, DatabaseWriter databaseWriter) {
+		editorialsFetcher = new EditorialsFetcher(jsoupDocumentFetcher);
+		this.databaseWriter = databaseWriter;
+	}
+
+	public synchronized void run(String publishedGoogleDocsUrl) {
+		running = true;
+		Editorials editorials;
+		try {
+			editorials = editorialsFetcher.getEditorials(publishedGoogleDocsUrl);
+		} catch (IOException e) {
+			Log.e(TAG, String.format("Failed to get editorials from %s: %s", publishedGoogleDocsUrl, e.getMessage()));
+			running = false;
+			return;
+		}
+		writeEditorials(editorials);
+		running = false;
+	}
+
+	private void writeEditorials(Editorials editorials) {
+		for (Editorial editorial : editorials) {
+			String charityId = editorial.getCharityId();
+			NGO ngo = new NGO(charityId);
+			ngo.put("recommendation", editorial.getEditorialText());
+			databaseWriter.upsertCharityRecord(ngo);
+		}
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+
+}

--- a/src/java/org/sogive/data/loader/JsoupDocumentFetcher.java
+++ b/src/java/org/sogive/data/loader/JsoupDocumentFetcher.java
@@ -1,0 +1,9 @@
+package org.sogive.data.loader;
+
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+
+public interface JsoupDocumentFetcher {
+    Document fetchDocument(String documentUrl) throws IOException;
+}

--- a/src/java/org/sogive/data/loader/JsoupDocumentFetcherImpl.java
+++ b/src/java/org/sogive/data/loader/JsoupDocumentFetcherImpl.java
@@ -1,0 +1,13 @@
+package org.sogive.data.loader;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+
+public class JsoupDocumentFetcherImpl implements JsoupDocumentFetcher {
+    @Override
+    public Document fetchDocument(String documentUrl) throws IOException {
+        return Jsoup.connect(documentUrl).get();
+    }
+}

--- a/src/java/org/sogive/server/ImportDataServlet.java
+++ b/src/java/org/sogive/server/ImportDataServlet.java
@@ -1,6 +1,6 @@
 package org.sogive.server;
 
-import org.sogive.data.loader.ImportOSCRData;
+import org.sogive.data.loader.*;
 
 import com.winterwell.web.WebEx;
 import com.winterwell.web.app.IServlet;
@@ -10,6 +10,7 @@ import com.winterwell.web.fields.SField;
 public class ImportDataServlet implements IServlet {
 
 	private static ImportOSCRData oscr;
+	private static ImportEditorialsDataTask importEditorialsTask;
 
 	@Override
 	public void process(WebRequest state) throws Exception {
@@ -20,6 +21,16 @@ public class ImportDataServlet implements IServlet {
 				throw new WebEx.E400("Repeat call");
 			}
 			oscr.run();
+		}
+		if ("editorials".equals(dataset)) {
+			String url = state.get("url");
+			JsoupDocumentFetcher jsoupDocumentFetcher = new JsoupDocumentFetcherImpl();
+			DatabaseWriter databaseWriter = new ElasticSearchDatabaseWriter();
+			importEditorialsTask = new ImportEditorialsDataTask(jsoupDocumentFetcher, databaseWriter);
+			if (importEditorialsTask.isRunning()) {
+				throw new WebEx.E400("Repeat call");
+			}
+			importEditorialsTask.run(url);
 		}
 	}
 

--- a/src/java/org/sogive/server/ImportDataServlet.java
+++ b/src/java/org/sogive/server/ImportDataServlet.java
@@ -7,6 +7,11 @@ import com.winterwell.web.app.IServlet;
 import com.winterwell.web.app.WebRequest;
 import com.winterwell.web.fields.SField;
 
+/**
+ * a bit hacky but useful: import data into SoGive 
+ * @author daniel
+ *
+ */
 public class ImportDataServlet implements IServlet {
 
 	private static ImportOSCRData oscr;
@@ -15,6 +20,7 @@ public class ImportDataServlet implements IServlet {
 	@Override
 	public void process(WebRequest state) throws Exception {
 		String dataset = state.getRequired(new SField("dataset"));
+		// Scottish official data?
 		if ("OSCR".equals(dataset)) {
 			oscr = new ImportOSCRData();
 			if (oscr.isRunning()) {
@@ -22,6 +28,7 @@ public class ImportDataServlet implements IServlet {
 			}
 			oscr.run();
 		}
+		// A Google doc of editorials?
 		if ("editorials".equals(dataset)) {
 			String url = state.get("url");
 			JsoupDocumentFetcher jsoupDocumentFetcher = new JsoupDocumentFetcherImpl();

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -11,6 +11,7 @@ import DataStore from '../../base/plumbing/DataStore';
 import ActionMan from '../../plumbing/ActionMan';
 // import ChartWidget from './../base/components/ChartWidget';
 import Misc from '../../base/components/Misc';
+import {notifyUser} from '../../base/plumbing/Messaging';
 
 
 const EditorDashboardPage = () => (
@@ -19,6 +20,7 @@ const EditorDashboardPage = () => (
 		<h3>In development...</h3>
 		<AddCharityWidget />
 		<AddEditorWidget />
+		<UploadEditorialsWidget />
 		<p><a href='/#manageDonations'>Manage Donations</a></p>
 	</div>
 ); // ./EditorDashboardPage
@@ -50,6 +52,22 @@ const AddEditorWidget = () => {
 		<p>Use this form to add someone to the editors team. Anyone can make edits, but only approved editors can publish them.</p>
 		<Misc.PropControl prop='email' label='Email' path={['widget','AddEditorWidget', 'form']} />
 		<button className='btn btn-warning' onClick={doAddEditor}>Add Them</button>
+	</Misc.Card>);
+};
+
+const doUploadEditorials = function() {
+	let googleDocUrl = DataStore.appstate.widget.UploadEditorialsWidget.form.publishedEditorialsDoc;
+	if ( ! googleDocUrl) return;
+	notifyUser("Successfully imported editorials.");
+	ServerIO.importEditorials(googleDocUrl);
+	DataStore.setValue(['widget', 'UploadEditorialsWidget', 'form'], {});
+};
+
+const UploadEditorialsWidget = () => {
+	return (<Misc.Card title='Upload Editorials' >
+		<p>Use this form to upload SoGive editorials from a published Google Doc.</p>
+		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label='Published google doc webpage URL:' path={['widget','UploadEditorialsWidget', 'form']} />
+		<button className='btn btn-warning' onClick={doUploadEditorials} name='uploadEditorials'>Upload Editorials</button>
 	</Misc.Card>);
 };
 

--- a/src/js/plumbing/ServerIO.js
+++ b/src/js/plumbing/ServerIO.js
@@ -89,4 +89,17 @@ ServerIO.addCharity = function(charity, status=C.KStatus.DRAFT) {
 	return ServerIO.load('/charity.json', params);
 };
 
+/**
+ * Import editorials for existing charities in database from a published Google doc.
+ * 
+ * @param publishedEditorialsUrl the URL of the pubslished Google doc containing SoGive editorials.
+ */
+ServerIO.importEditorials = function(publishedEditorialsUrl) {
+	let params = {
+		data: {	dataset: 'editorials', url: publishedEditorialsUrl },
+		method: 'PUT'
+	};
+	return ServerIO.load('/import.json', params)
+};
+
 export default ServerIO;

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -1,0 +1,62 @@
+// checks functionality of sogive.org/#edit
+const puppeteer = require('puppeteer');
+const { doLogin,serverSafetyCheck } = require("../test-base/UtilityFunctions");
+const { username, password } = require("../Credentials");
+const { CommonSelectors, Search, General } = require('../SoGiveSelectors');
+const { targetServers } = require('../testConfig');
+
+const config = JSON.parse(process.env.__CONFIGURATION);
+
+const baseSite = targetServers[config.site];
+const protocol = config.site === 'local' ? 'http://' : 'https://';
+
+let url = `${baseSite}`;
+const charityId = "tbd";
+const expectedEditorial = "tbd is an okay charity doing mediocre things\nso overall we think they are bronze"
+let editorialsUrl = 'https://docs.google.com/document/d/e/2PACX-1vTJ018R_FZ1_efPZKe17KhjPajEzm_folfOdSUUNtBDyBCK-URyOQ02K7K9TxsEotv5oSMUOdkZZV_m/pub';
+
+// Increase default timeout to prevent occasional flaky failures.
+// Note, this must be higher than any specific timeouts set within the tests below, otherwise they have no effect.
+jest.setTimeout(30000);
+
+describe('Editor dashboard tests', () => {
+
+	test('Upload charity editorials from published gdoc', async () => {
+		await page.goto(`${url}#editordashboard`);
+
+		// log in
+		await page.click('.login-link');
+		await page.click('.login-email [name=email]');
+		await page.type('.login-email [name=email]', username);
+		await page.click('[name=password]');
+		await page.type('[name=password]', password);
+		await page.keyboard.press('Enter');
+		// wait for login dialog to disappear
+		// (decrease timeout so we fail-fast & get a better error message if it doesn't)
+		await page.waitForSelector('.login-email [name=email]', { hidden: true, timeout: 5000 });
+
+		await page.type('[name=editorialsUrl]', editorialsUrl);
+		await page.click('[name=uploadEditorials]');
+
+		// give elastic search time to update
+		await page.waitFor(1000);
+
+		await(page.waitForSelector('div.alert'))
+		const alertMessage = await page.$eval('div.alert', e => e.innerText);
+		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported editorials'));
+
+		const editorialsUrlText = await page.$eval('[name=editorialsUrl]', e => e.value);
+		expect (editorialsUrlText).toBe('');
+
+		// navigate to charity page
+		await page.goto(`${url}#charity?charityId=${charityId}`);
+
+		// click on 'Analysis'
+		await page.waitForSelector('#rhsTabs');
+		await page.click('#rhsTabs .nav-item:not(.active) a.nav-link');
+
+		const charityEditorial = await page.$$eval('.charity-extra .quote p', els => els.map(el => el.innerText).join('\n'));
+		expect(charityEditorial).toEqual(expectedEditorial);
+	});
+
+});

--- a/test/java/org/sogive/data/loader/FakeJsoupDocumentFetcher.java
+++ b/test/java/org/sogive/data/loader/FakeJsoupDocumentFetcher.java
@@ -8,8 +8,8 @@ import java.util.Map;
 class FakeJsoupDocumentFetcher implements JsoupDocumentFetcher {
     private final Map<String, Document> documents = new HashMap<>();
 
-    public void setDocumentAtUrl(String url, Document document) {
-        documents.put(url, document);
+    public void setDocumentAtUrl(Document document) {
+        documents.put(document.baseUri(), document);
     }
 
     @Override

--- a/test/java/org/sogive/data/loader/FakeJsoupDocumentFetcher.java
+++ b/test/java/org/sogive/data/loader/FakeJsoupDocumentFetcher.java
@@ -1,0 +1,19 @@
+package org.sogive.data.loader;
+
+import org.jsoup.nodes.Document;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class FakeJsoupDocumentFetcher implements JsoupDocumentFetcher {
+    private final Map<String, Document> documents = new HashMap<>();
+
+    public void setDocumentAtUrl(String url, Document document) {
+        documents.put(url, document);
+    }
+
+    @Override
+    public Document fetchDocument(String publishedGoogleDocsUrl) {
+        return documents.get(publishedGoogleDocsUrl);
+    }
+}

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -1,0 +1,109 @@
+package org.sogive.data.loader;
+
+import com.google.common.collect.ImmutableMap;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.sogive.data.charity.NGO;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImportEditorialsDataTaskTest {
+
+    /**
+     * Valid-looking published google docs url.
+     */
+    private static final String VALID_URL =
+            "https://docs.google.com/document/d/e/some-random-string-jkcldsnuw/pub";
+    private static final String TBD_CHARITY_ID = "tbd";
+    private static final String TBD_CHARITY_EDITORIAL_TEXT = "tbd is a wonderful charity doing all sorts of amazing things";
+
+    private ImportEditorialsDataTask importEditorialsDataTask;
+    private InMemoryDatabaseWriter databaseWriter;
+    private FakeJsoupDocumentFetcher fakeDocumentFetcher;
+
+    @Before
+    public void setUp() {
+        fakeDocumentFetcher = new FakeJsoupDocumentFetcher();
+        databaseWriter = new InMemoryDatabaseWriter();
+        importEditorialsDataTask = new ImportEditorialsDataTask(fakeDocumentFetcher, databaseWriter);
+    }
+
+    @Test
+    public void testImportEditorials_singleCharity_oneLineEditorial() {
+        fakeDocumentFetcher.setDocumentAtUrl(
+                VALID_URL,
+                generateDocumentContainingCharityEditorials(ImmutableMap.of(
+                        TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
+
+        importEditorialsDataTask.run(VALID_URL);
+
+        assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
+    }
+
+    @Test
+    public void testImportEditorials_singleCharity_multiParagraphEditorial() {
+        fakeDocumentFetcher.setDocumentAtUrl(
+                VALID_URL,
+                generateDocumentContainingCharityEditorials(ImmutableMap.of(
+                        TBD_CHARITY_ID, Arrays.asList("first paragraph", "second paragraph"))));
+
+        importEditorialsDataTask.run(VALID_URL);
+
+        assertEquals("first paragraph\n\nsecond paragraph", databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
+    }
+
+    @Test
+    public void testImportEditorials_multipleCharities() {
+        fakeDocumentFetcher.setDocumentAtUrl(
+                VALID_URL,
+                generateDocumentContainingCharityEditorials(ImmutableMap.of(
+                        "charity-one", Collections.singletonList("Charity One Editorial"),
+                        "charity-two", Arrays.asList("Charity Two Editorial", "Second paragraph"))));
+
+        importEditorialsDataTask.run(VALID_URL);
+
+        assertEquals("Charity One Editorial", databaseWriter.getCharityRecommendation("charity-one"));
+        assertEquals("Charity Two Editorial\n\nSecond paragraph", databaseWriter.getCharityRecommendation("charity-two"));
+    }
+
+    private static Document generateDocumentContainingCharityEditorials(Map<String, List<String>> charityEditorials) {
+        // Copied from a real published google doc source.
+        StringBuilder html = new StringBuilder("<html><head></head><body><div id=\"header\"><div id=\"title\">charity test</div>" +
+                "<div id=\"interval\"><span>Updated automatically every 5 minutes</span></div></div>" +
+                "<div id=\"contents\"><div class=\"c1\">");
+        for (Map.Entry<String, List<String>> editorial : charityEditorials.entrySet()) {
+            String headerHtml =
+                    "<h1 class=\"c3\" id=\"h.nqhynfkjytlx\"><span class=\"c4\">" + editorial.getKey() + "</span></h1>";
+            html.append(headerHtml);
+            String editorialsHtml = editorial.getValue().stream()
+                    .map(paragraph -> "<p class=\"c0\"><span class=\"c2\">" + paragraph + "</span></p>")
+                    .collect(Collectors.joining("<p class=\"c2\"><span class=\"c1\"></span></p>"));
+            html.append(editorialsHtml);
+        }
+        html.append("</div></div></body></html>");
+        return Jsoup.parse(html.toString());
+    }
+
+    private static class InMemoryDatabaseWriter implements DatabaseWriter {
+
+        private final Map<String, NGO> charityRecords;
+
+        private InMemoryDatabaseWriter() {
+            charityRecords = new HashMap<>();
+        }
+
+        @Override
+        public void upsertCharityRecord(NGO ngo) {
+            charityRecords.put(ngo.getId(), ngo);
+        }
+
+        public String getCharityRecommendation(String charityId) {
+            return (String) charityRecords.get(charityId).get("recommendation");
+        }
+    }
+}

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -3,6 +3,7 @@ package org.sogive.data.loader;
 import com.google.common.collect.ImmutableMap;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.Before;
 import org.junit.Test;
 import org.sogive.data.charity.NGO;
@@ -75,16 +76,26 @@ public class ImportEditorialsDataTaskTest {
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2() {
         databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
-        // TODO: fake an editorial containing a header two
-        fakeDocumentFetcher.setDocumentAtUrl(
-                VALID_URL,
-                generateDocumentContainingCharityEditorials(ImmutableMap.of(
-                        TBD_CHARITY_ID, Arrays.asList("first paragraph", "second paragraph"))));
+
+        Document document = Document.createShell(VALID_URL);
+
+        Element headerDiv = new Element("div");
+        document.appendChild(headerDiv);
+
+        Element contentsDiv = new Element("div");
+        contentsDiv.appendChild(new Element("h1").text(TBD_CHARITY_ID));
+        contentsDiv.appendChild(new Element("p").text("paragraph text"));
+        contentsDiv.appendChild(new Element("p").text("second paragraph text"));
+        contentsDiv.appendChild(new Element("h2").text("**Section Header**"));
+        contentsDiv.appendChild(new Element("p").text("more paragraph text"));
+        document.appendChild(contentsDiv);
+
+        fakeDocumentFetcher.setDocumentAtUrl(VALID_URL, document);
 
         importEditorialsDataTask.run(VALID_URL);
 
-        // TODO proper assert
-        assertTrue(false);
+        assertEquals("paragraph text\n\nsecond paragraph text\n\n**Section Header**\n\nmore paragraph text",
+                databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
 
     @Test

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -1,7 +1,6 @@
 package org.sogive.data.loader;
 
 import com.google.common.collect.ImmutableMap;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Before;
@@ -9,19 +8,19 @@ import org.junit.Test;
 import org.sogive.data.charity.NGO;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
+@SuppressWarnings("SameParameterValue")
 public class ImportEditorialsDataTaskTest {
 
     /**
      * Valid-looking published google docs url.
      */
-    private static final String VALID_URL =
-            "https://docs.google.com/document/d/e/some-random-string-jkcldsnuw/pub";
+    private static final String TEST_URL = "https://docs.google.com/document/d/e/some-random-string-jkcldsnuw/pub";
     private static final String TBD_CHARITY_ID = "tbd";
-    private static final String TBD_CHARITY_EDITORIAL_TEXT = "tbd is a wonderful charity doing all sorts of amazing things";
+    private static final String TBD_CHARITY_EDITORIAL_TEXT =
+            "tbd is a wonderful charity doing all sorts of amazing things";
 
     private ImportEditorialsDataTask importEditorialsDataTask;
     private InMemoryDatabaseWriter databaseWriter;
@@ -39,11 +38,11 @@ public class ImportEditorialsDataTaskTest {
         databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
 
         fakeDocumentFetcher.setDocumentAtUrl(
-                VALID_URL,
-                generateDocumentContainingCharityEditorials(ImmutableMap.of(
-                        TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
 
-        importEditorialsDataTask.run(VALID_URL);
+        importEditorialsDataTask.run(TEST_URL);
 
         assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
@@ -51,11 +50,11 @@ public class ImportEditorialsDataTaskTest {
     @Test
     public void testImportEditorials_singleCharity_notInDatabase_doesNotImport() {
         fakeDocumentFetcher.setDocumentAtUrl(
-                VALID_URL,
-                generateDocumentContainingCharityEditorials(ImmutableMap.of(
-                        TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
 
-        importEditorialsDataTask.run(VALID_URL);
+        importEditorialsDataTask.run(TEST_URL);
 
         assertNull(databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
@@ -64,20 +63,20 @@ public class ImportEditorialsDataTaskTest {
     public void testImportEditorials_singleCharity_multiParagraphEditorial_alreadyInDatabase() {
         databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
         fakeDocumentFetcher.setDocumentAtUrl(
-                VALID_URL,
-                generateDocumentContainingCharityEditorials(ImmutableMap.of(
-                        TBD_CHARITY_ID, Arrays.asList("first paragraph", "second paragraph"))));
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of(TBD_CHARITY_ID, Arrays.asList("first paragraph", "second paragraph"))));
 
-        importEditorialsDataTask.run(VALID_URL);
+        importEditorialsDataTask.run(TEST_URL);
 
         assertEquals("first paragraph\n\nsecond paragraph", databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
 
     @Test
-    public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2() {
+    public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2_alreadyInDatabase() {
         databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
 
-        Document document = Document.createShell(VALID_URL);
+        Document document = Document.createShell(TEST_URL);
 
         Element headerDiv = new Element("div");
         document.appendChild(headerDiv);
@@ -90,9 +89,9 @@ public class ImportEditorialsDataTaskTest {
         contentsDiv.appendChild(new Element("p").text("more paragraph text"));
         document.appendChild(contentsDiv);
 
-        fakeDocumentFetcher.setDocumentAtUrl(VALID_URL, document);
+        fakeDocumentFetcher.setDocumentAtUrl(document);
 
-        importEditorialsDataTask.run(VALID_URL);
+        importEditorialsDataTask.run(TEST_URL);
 
         assertEquals("paragraph text\n\nsecond paragraph text\n\n**Section Header**\n\nmore paragraph text",
                 databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
@@ -103,33 +102,48 @@ public class ImportEditorialsDataTaskTest {
         databaseWriter.upsertCharityRecord(new NGO("charity-one"));
         databaseWriter.upsertCharityRecord(new NGO("charity-two"));
         fakeDocumentFetcher.setDocumentAtUrl(
-                VALID_URL,
-                generateDocumentContainingCharityEditorials(ImmutableMap.of(
-                        "charity-one", Collections.singletonList("Charity One Editorial"),
-                        "charity-two", Arrays.asList("Charity Two Editorial", "Second paragraph"))));
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of(
+                                "charity-one", Collections.singletonList("Charity One Editorial"),
+                                "charity-two", Arrays.asList("Charity Two Editorial", "Second paragraph"))));
 
-        importEditorialsDataTask.run(VALID_URL);
+        importEditorialsDataTask.run(TEST_URL);
 
         assertEquals("Charity One Editorial", databaseWriter.getCharityRecommendation("charity-one"));
-        assertEquals("Charity Two Editorial\n\nSecond paragraph", databaseWriter.getCharityRecommendation("charity-two"));
+        assertEquals("Charity Two Editorial\n\nSecond paragraph",
+                databaseWriter.getCharityRecommendation("charity-two"));
     }
 
-    private static Document generateDocumentContainingCharityEditorials(Map<String, List<String>> charityEditorials) {
-        // Copied from a real published google doc source.
-        StringBuilder html = new StringBuilder("<html><head></head><body><div id=\"header\"><div id=\"title\">charity test</div>" +
-                "<div id=\"interval\"><span>Updated automatically every 5 minutes</span></div></div>" +
-                "<div id=\"contents\"><div class=\"c1\">");
+    private static Document generateDocumentContainingCharityEditorials(
+            String baseUri, Map<String, List<String>> charityEditorials) {
+        Document document = Document.createShell(baseUri);
+        // Structure below copied from a real published google doc source.
+
+        Element headerDiv = new Element("div").attr("id", "header");
+        document.appendChild(headerDiv);
+
+        Element contentsDiv = new Element("div").attr("id", "contents");
+        Element c1Div = new Element("div").addClass("c1");
+
         for (Map.Entry<String, List<String>> editorial : charityEditorials.entrySet()) {
-            String headerHtml =
-                    "<h1 class=\"c3\" id=\"h.nqhynfkjytlx\"><span class=\"c4\">" + editorial.getKey() + "</span></h1>";
-            html.append(headerHtml);
-            String editorialsHtml = editorial.getValue().stream()
-                    .map(paragraph -> "<p class=\"c0\"><span class=\"c2\">" + paragraph + "</span></p>")
-                    .collect(Collectors.joining("<p class=\"c2\"><span class=\"c1\"></span></p>"));
-            html.append(editorialsHtml);
+            Element headerElement = new Element("h1").addClass("c3");
+            headerElement.appendChild(new Element("span").addClass("c4").text(editorial.getKey()));
+            c1Div.appendChild(headerElement);
+
+            for (String paragraph : editorial.getValue()) {
+                Element paragraphElement = new Element("p").addClass("c0");
+                paragraphElement.appendChild(new Element("span").addClass("c2").text(paragraph));
+                c1Div.appendChild(paragraphElement);
+
+                Element emptyParagraph = new Element("p").addClass("c2");
+                emptyParagraph.appendChild(new Element("span").addClass("c1"));
+                c1Div.appendChild(emptyParagraph);
+            }
         }
-        html.append("</div></div></body></html>");
-        return Jsoup.parse(html.toString());
+        contentsDiv.appendChild(c1Div);
+        document.appendChild(contentsDiv);
+        return document;
     }
 
     private static class InMemoryDatabaseWriter implements DatabaseWriter {


### PR DESCRIPTION
Tasks:
- [x] (failing) Puppeteer test that pressing Import Editorials button on Editor Dashboard with a particular google docs url imports expected editorial.

- [x]  Populate the google doc used in test with expected editorial in expected format (copy from the current SoGive editorials doc)

- [x]  Get the content of the google doc as HTML

- [x] Parse the HTML into list of charity ids - editorials

- [x] Write editorials to sogive database (puppeteer test should now pass)

- [x] Don't import editorials for charities not in the database.

- [ ] Editor Dashboard UI improvements

  - [ ] explain about it needing to be a *published* google doc

  - [ ] change wording to 'import' not 'upload'

- [ ] Error-handling - for badly formatted google docs / docs containing no editorials - should show message to user, at least showing how many editorials were imported.

- [ ]  Auth - disallow requests to upload from non-editors. (how??)