### PR TITLE
Add IntelliJ-generated project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ build-lib
 package-lock.json
 web/style
 uploads
+
+# IntelliJ project files
+.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ uploads
 # IntelliJ project files
 .idea
 *.iml
+target/


### PR DESCRIPTION
This should allow me to develop faster in my preferred IDE while not accidentally committing IntelliJ-generated files

For the record, I could only get IntelliJ to import the project by importing it as a Maven project, *not* by importing it as an Eclipse project. But then it was possible to import the other projects as Eclipse modules (from Project Structure settings) & this worked better than attempting to import them as Maven modules.