### PR TITLE
Fixes for the editorials importer tool

### DIFF
--- a/src/java/org/sogive/data/loader/EditorialsFetcher.java
+++ b/src/java/org/sogive/data/loader/EditorialsFetcher.java
@@ -34,7 +34,7 @@ public class EditorialsFetcher {
         List<Editorial> charityEditorials = new ArrayList<>();
         Elements header1s = document.getElementsByTag("h1");
         for (Element h1 : header1s) {
-            String charityId = h1.text().trim();
+            String charityId = h1.text().trim().toLowerCase();
             List<String> editorialParagraphs = new ArrayList<>();
 
             Element firstParagraphElement = h1.nextElementSibling();

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -30,7 +30,7 @@ public class ImportEditorialsDataTask {
 		this.database = database;
 	}
 
-	public synchronized void run(String publishedGoogleDocsUrl) {
+	public synchronized int run(String publishedGoogleDocsUrl) {
 		running = true;
 		try {
 			Editorials editorials;
@@ -39,9 +39,9 @@ public class ImportEditorialsDataTask {
 			} catch (IOException e) {
 				Log.e(TAG, String.format("Failed to get editorials from %s: %s", publishedGoogleDocsUrl, e.getMessage()));
 				running = false;
-				return;
+				return 0;
 			}
-			writeEditorials(editorials);
+			return writeEditorials(editorials);
 		} catch(Throwable ex) {
 			throw Utils.runtime(ex);
 		} finally {
@@ -49,7 +49,8 @@ public class ImportEditorialsDataTask {
 		}
 	}
 
-	private void writeEditorials(Editorials editorials) {
+	private int writeEditorials(Editorials editorials) {
+		int count = 0;
 		for (Editorial editorial : editorials) {
 			String charityId = editorial.getCharityId();
 			// If it's not already in the charity database, we don't want to insert it.
@@ -59,7 +60,9 @@ public class ImportEditorialsDataTask {
 			NGO ngo = new NGO(charityId);
 			ngo.put("recommendation", editorial.getEditorialText());
 			database.upsertCharityRecord(ngo);
+			count++;
 		}
+		return count;
 	}
 
 	public boolean isRunning() {

--- a/src/java/org/sogive/server/ImportDataServlet.java
+++ b/src/java/org/sogive/server/ImportDataServlet.java
@@ -1,5 +1,9 @@
 package org.sogive.server;
 
+import com.winterwell.utils.containers.ArrayMap;
+import com.winterwell.utils.log.Log;
+import com.winterwell.utils.web.WebUtils2;
+import com.winterwell.web.ajax.JsonResponse;
 import org.sogive.data.loader.*;
 
 import com.winterwell.web.WebEx;
@@ -37,7 +41,11 @@ public class ImportDataServlet implements IServlet {
 			if (importEditorialsTask.isRunning()) {
 				throw new WebEx.E400("Repeat call");
 			}
-			importEditorialsTask.run(url);
+			int totalImported = importEditorialsTask.run(url);
+			JsonResponse output = new JsonResponse(state, new ArrayMap(
+					"totalImported", totalImported
+			));
+			WebUtils2.sendJson(output, state);
 		}
 	}
 

--- a/src/java/org/sogive/server/ImportDataServlet.java
+++ b/src/java/org/sogive/server/ImportDataServlet.java
@@ -41,10 +41,8 @@ public class ImportDataServlet implements IServlet {
 			if (importEditorialsTask.isRunning()) {
 				throw new WebEx.E400("Repeat call");
 			}
-			int totalImported = importEditorialsTask.run(url);
-			JsonResponse output = new JsonResponse(state, new ArrayMap(
-					"totalImported", totalImported
-			));
+			ArrayMap result = importEditorialsTask.run(url);
+			JsonResponse output = new JsonResponse(state, result);
 			WebUtils2.sendJson(output, state);
 		}
 	}

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -60,7 +60,8 @@ const doImportEditorials = function() {
 	if ( ! googleDocUrl) return;
 	ServerIO.importEditorials(googleDocUrl)
 		.then(importResult => {
-			notifyUser("Successfully imported editorials.");
+			const totalImported = importResult.cargo.totalImported;
+			notifyUser("Successfully imported " + totalImported + " editorials.");
 		})
 		.catch(errorResponse => {
 			console.log("Error importing editorials: ", errorResponse);

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -76,6 +76,7 @@ const ImportEditorialsWidget = () => {
 		<p>Import Instructions:</p>
 		<ol>
 			<li>Open the Google Doc</li>
+			<li>Open the document outline (View &gt; Show document outline, or click on the icon on the left-hand side) and check that all the charity-ids are styled as Heading 1s.</li>
 			<li>In the Docs menu, select <b>File</b> &gt; <b>Publish to the web</b>, and click <b>[Publish]</b>.</li>
 			<li>Copy the link from that dialog.</li>
 		</ol>

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -9,21 +9,25 @@ import printer from '../../base/utils/printer';
 import ServerIO from '../../plumbing/ServerIO';
 import DataStore from '../../base/plumbing/DataStore';
 import ActionMan from '../../plumbing/ActionMan';
+import { LoginLink } from '../../base/components/LoginWidget';
 // import ChartWidget from './../base/components/ChartWidget';
 import Misc from '../../base/components/Misc';
 import {notifyUser} from '../../base/plumbing/Messaging';
 
 
-const EditorDashboardPage = () => (
-	<div className="page EditorDashboardPage">
+const EditorDashboardPage = () => {
+	if ( ! Login.isLoggedIn()) {
+		return <LoginLink />;
+	}
+	return (<div className="page EditorDashboardPage">
 		<h2>Editorial Dashboard</h2>
 		<h3>In development...</h3>
 		<AddCharityWidget />
 		<AddEditorWidget />
 		<ImportEditorialsWidget />
 		<p><a href='/#manageDonations'>Manage Donations</a></p>
-	</div>
-); // ./EditorDashboardPage
+	</div>);
+}; // ./EditorDashboardPage
 
 
 const AddCharityWidget = () => {

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -65,8 +65,21 @@ const doImportEditorials = function() {
 
 const ImportEditorialsWidget = () => {
 	return (<Misc.Card title='Import Editorials' >
-		<p>Use this form to import SoGive editorials from a published Google Doc.</p>
-		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label='Published google doc webpage URL:' path={['widget','ImportEditorialsWidget', 'form']} />
+		<p>Use this form to import SoGive editorials from a Google Doc. Editorials in the doc must be in the following format:</p>
+		<br/>
+		<p><b>charity-id-1</b> (styled as Heading 1)</p>
+		<p>Editorial One (styled as Normal text or subheadings, may be multiple paragraphs)</p>
+		<p><b>charity-id-2</b> (styled as Heading 1)</p>
+		<p>Editorial Two (styled as Normal text or subheadings, may be multiple paragraphs)</p>
+		<p>etc.</p>
+		<br/>
+		<p>Import Instructions:</p>
+		<ol>
+			<li>Open the Google Doc</li>
+			<li>In the Docs menu, select <b>File</b> &gt; <b>Publish to the web</b>, and click <b>[Publish]</b>.</li>
+			<li>Copy the link from that dialog.</li>
+		</ol>
+		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label="Published link: (should end in '/pub')" path={['widget','ImportEditorialsWidget', 'form']} />
 		<button className='btn btn-warning' onClick={doImportEditorials} name='importEditorials'>Import Editorials</button>
 	</Misc.Card>);
 };

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -58,8 +58,13 @@ const AddEditorWidget = () => {
 const doImportEditorials = function() {
 	let googleDocUrl = DataStore.appstate.widget.ImportEditorialsWidget.form.publishedEditorialsDoc;
 	if ( ! googleDocUrl) return;
-	notifyUser("Successfully imported editorials.");
-	ServerIO.importEditorials(googleDocUrl);
+	ServerIO.importEditorials(googleDocUrl)
+		.then(importResult => {
+			notifyUser("Successfully imported editorials.");
+		})
+		.catch(errorResponse => {
+			console.log("Error importing editorials: ", errorResponse);
+		});
 	DataStore.setValue(['widget', 'ImportEditorialsWidget', 'form'], {});
 };
 

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -13,11 +13,15 @@ import { LoginLink } from '../../base/components/LoginWidget';
 // import ChartWidget from './../base/components/ChartWidget';
 import Misc from '../../base/components/Misc';
 import {notifyUser} from '../../base/plumbing/Messaging';
+import ShareWidget, {AccessDenied} from '../../base/components/ShareWidget';
 
 
 const EditorDashboardPage = () => {
 	if ( ! Login.isLoggedIn()) {
 		return <LoginLink />;
+	}
+	if ( ! Roles.iCan(C.CAN.edit).value ) {
+		return <AccessDenied/>
 	}
 	return (<div className="page EditorDashboardPage">
 		<h2>Editorial Dashboard</h2>

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -60,8 +60,13 @@ const AddEditorWidget = () => {
 };
 
 const doImportEditorials = function() {
-	let googleDocUrl = DataStore.appstate.widget.ImportEditorialsWidget.form.publishedEditorialsDoc;
-	if ( ! googleDocUrl) return;
+	const googleDocUrl = DataStore.appstate.widget.ImportEditorialsWidget.form.publishedEditorialsDoc;
+	if ( ! googleDocUrl ) return;
+	if ( googleDocUrl.slice(-4) !== '/pub') {
+		DataStore.setValue(['widget', 'ImportEditorialsWidget', 'form'], {});
+		notifyUser(new Error("Link given *must* end in /pub - Please read instructions!"))
+		return;
+	}
 	ServerIO.importEditorials(googleDocUrl)
 		.then(importResult => {
 			const totalImported = importResult.cargo.totalImported;
@@ -77,6 +82,7 @@ const doImportEditorials = function() {
 		})
 		.catch(errorResponse => {
 			console.log("Error importing editorials: ", errorResponse);
+			DataStore.setValue(['widget', 'ImportEditorialsWidget', 'form'], {});
 		});
 	DataStore.setValue(['widget', 'ImportEditorialsWidget', 'form'], {});
 };

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -20,7 +20,7 @@ const EditorDashboardPage = () => (
 		<h3>In development...</h3>
 		<AddCharityWidget />
 		<AddEditorWidget />
-		<UploadEditorialsWidget />
+		<ImportEditorialsWidget />
 		<p><a href='/#manageDonations'>Manage Donations</a></p>
 	</div>
 ); // ./EditorDashboardPage
@@ -55,19 +55,19 @@ const AddEditorWidget = () => {
 	</Misc.Card>);
 };
 
-const doUploadEditorials = function() {
-	let googleDocUrl = DataStore.appstate.widget.UploadEditorialsWidget.form.publishedEditorialsDoc;
+const doImportEditorials = function() {
+	let googleDocUrl = DataStore.appstate.widget.ImportEditorialsWidget.form.publishedEditorialsDoc;
 	if ( ! googleDocUrl) return;
 	notifyUser("Successfully imported editorials.");
 	ServerIO.importEditorials(googleDocUrl);
-	DataStore.setValue(['widget', 'UploadEditorialsWidget', 'form'], {});
+	DataStore.setValue(['widget', 'ImportEditorialsWidget', 'form'], {});
 };
 
-const UploadEditorialsWidget = () => {
-	return (<Misc.Card title='Upload Editorials' >
-		<p>Use this form to upload SoGive editorials from a published Google Doc.</p>
-		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label='Published google doc webpage URL:' path={['widget','UploadEditorialsWidget', 'form']} />
-		<button className='btn btn-warning' onClick={doUploadEditorials} name='uploadEditorials'>Upload Editorials</button>
+const ImportEditorialsWidget = () => {
+	return (<Misc.Card title='Import Editorials' >
+		<p>Use this form to import SoGive editorials from a published Google Doc.</p>
+		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label='Published google doc webpage URL:' path={['widget','ImportEditorialsWidget', 'form']} />
+		<button className='btn btn-warning' onClick={doImportEditorials} name='importEditorials'>Import Editorials</button>
 	</Misc.Card>);
 };
 

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -61,7 +61,15 @@ const doImportEditorials = function() {
 	ServerIO.importEditorials(googleDocUrl)
 		.then(importResult => {
 			const totalImported = importResult.cargo.totalImported;
-			notifyUser("Successfully imported " + totalImported + " editorials.");
+			if (totalImported > 0) {
+				notifyUser("Successfully imported " + totalImported + " editorials.");
+			}
+			const rejectedIds = importResult.cargo.rejectedIds;
+			if (rejectedIds && rejectedIds.length > 0) {
+				let errorMessage = `Rejected ${rejectedIds.length} charities not in database:\n`;
+				errorMessage += rejectedIds.join(", ");
+				notifyUser(new Error(errorMessage))
+			}
 		})
 		.catch(errorResponse => {
 			console.log("Error importing editorials: ", errorResponse);

--- a/src/js/plumbing/ServerIO.js
+++ b/src/js/plumbing/ServerIO.js
@@ -16,7 +16,7 @@ import Messaging, {notifyUser} from '../base/plumbing/Messaging';
 import ServerIO from '../base/plumbing/ServerIOBase';
 
 ServerIO.APIBASE = '';
-ServerIO.APIBASE = 'https://test.sogive.org';
+// ServerIO.APIBASE = 'https://test.sogive.org';
 // ServerIO.APIBASE = 'https://app.sogive.org';
 
 // ?? use media.good-loop.com??

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -58,7 +58,7 @@ describe('Editor dashboard tests', () => {
 		await page.type('[name=editorialsUrl]', publishedUrlWithCharityInDbEditorial);
 		await page.click('[name=importEditorials]');
 
-		await(page.waitForSelector('.MessageBar div.alert-warning'))
+		await(page.waitForSelector('.MessageBar div.alert-warning', { timeout: 3000 }))
 		const alertMessage = await page.$eval('.MessageBar div.alert-warning', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported 1 editorials'));
 

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -49,8 +49,8 @@ describe('Editor dashboard tests', () => {
 	afterEach(async () => {
 		// dismiss any leftover notifications
 		await page.evaluate(() => {
-			document.querySelectorAll(".alert-warning > .close").forEach(el => el.click());
-			document.querySelectorAll(".alert-danger > .close").forEach(el => el.click());
+			document.querySelectorAll(".MessageBar .alert-warning > .close").forEach(el => el.click());
+			document.querySelectorAll(".MessageBar .alert-danger > .close").forEach(el => el.click());
 		});
 	});
 
@@ -84,8 +84,8 @@ describe('Editor dashboard tests', () => {
 
 		await page.click('[name=importEditorials]');
 
-		await(page.waitForSelector('div.alert-danger'))
-		const alertMessage = await page.$eval('div.alert', e => e.innerText);
+		await(page.waitForSelector('.MessageBar div.alert-danger'))
+		const alertMessage = await page.$eval('.MessageBar div.alert', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Malformed URL'));
 	});
 
@@ -96,8 +96,8 @@ describe('Editor dashboard tests', () => {
 		// give elastic search time to update
 		await page.waitFor(1000);
 
-		await(page.waitForSelector('div.alert'))
-		const alertMessage = await page.$eval('div.alert', e => e.innerText);
+		await(page.waitForSelector('.MessageBar div.alert'))
+		const alertMessage = await page.$eval('.MessageBar div.alert', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported 0 editorials'));
 
 		// TODO: Test we notify the user which charity editorials were rejected.

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -77,13 +77,23 @@ describe('Editor dashboard tests', () => {
 	});
 
 	test('Show error notification for a malformed URL', async () => {
-		await page.type('[name=editorialsUrl]', "foobarjckdsljkldjkls");
+		await page.type('[name=editorialsUrl]', "2PACX-1vRk52OOb1-yS3hejnqdeGfjT6m5wIXBYcjVGqaxDwYcpJZVVeefR6IpED8tMb09O_9PIE-c0YFkhpBR/pub");
 
 		await page.click('[name=importEditorials]');
 
-		await(page.waitForSelector('.MessageBar div.alert-danger'))
+		await(page.waitForSelector('.MessageBar div.alert-danger', { timeout: 3000 }))
 		const alertMessage = await page.$eval('.MessageBar div.alert-danger', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Malformed URL'));
+	});
+
+	test('Show error notification for URL not ending in /pub', async () => {
+		await page.type('[name=editorialsUrl]', "https://docs.google.com/document/d/1A4dPVA2SxgynQa7DrRJi59pC0DxGxiFS0q9M2fVcDxI/edit");
+
+		await page.click('[name=importEditorials]');
+
+		await(page.waitForSelector('.MessageBar div.alert-danger', { timeout: 3000 }))
+		const alertMessage = await page.$eval('.MessageBar div.alert-danger', e => e.innerText);
+		expect(alertMessage).toEqual(expect.stringContaining('Link given *must* end in /pub'));
 	});
 
 	test('Do not import editorials for charities not in the database', async () => {

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -97,4 +97,18 @@ describe('Editor dashboard tests', () => {
 		expect(alertDanger).toEqual(expect.stringContaining('yet-another-unknown-charity'));
 	});
 
+	test('Do not show dashboard when logged out', async () => {
+		// Log out
+		await page.click('.navbar .dropdown-toggle');
+		await page.click('.logout-link');
+		await page.waitForSelector('.login-link');
+
+		// Logging out takes you back to the homepage, so navigate back to the dashboard
+		await page.goto(`${sogiveUrl}#editordashboard`);
+
+		await expect(page).not.toMatchElement('.EditorDashboardPage');
+		await expect(page).not.toMatchElement('[name=importEditorials]');
+		await expect(page).toMatch('Log in');
+	});
+
 });

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -13,6 +13,8 @@ const protocol = config.site === 'local' ? 'http://' : 'https://';
 let url = `${baseSite}`;
 const charityId = "tbd";
 const expectedEditorial = "tbd is an okay charity doing mediocre things\nso overall we think they are bronze"
+
+// Published doc containing charityId (as a Header 2) followed by expectedEditorial
 let editorialsUrl = 'https://docs.google.com/document/d/e/2PACX-1vTJ018R_FZ1_efPZKe17KhjPajEzm_folfOdSUUNtBDyBCK-URyOQ02K7K9TxsEotv5oSMUOdkZZV_m/pub';
 
 // Increase default timeout to prevent occasional flaky failures.
@@ -21,7 +23,7 @@ jest.setTimeout(30000);
 
 describe('Editor dashboard tests', () => {
 
-	test('Upload charity editorials from published gdoc', async () => {
+	test('Import charity editorials from published gdoc', async () => {
 		await page.goto(`${url}#editordashboard`);
 
 		// log in
@@ -36,7 +38,7 @@ describe('Editor dashboard tests', () => {
 		await page.waitForSelector('.login-email [name=email]', { hidden: true, timeout: 5000 });
 
 		await page.type('[name=editorialsUrl]', editorialsUrl);
-		await page.click('[name=uploadEditorials]');
+		await page.click('[name=importEditorials]');
 
 		// give elastic search time to update
 		await page.waitFor(1000);

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -16,6 +16,9 @@ const expectedEditorial = "tbd is an okay charity doing mediocre things\nso over
 // Published doc containing {idOfCharityInDb} followed by {expectedEditorial}, in correct format
 const publishedUrlWithCharityInDbEditorial = 'https://docs.google.com/document/d/e/2PACX-1vTJ018R_FZ1_efPZKe17KhjPajEzm_folfOdSUUNtBDyBCK-URyOQ02K7K9TxsEotv5oSMUOdkZZV_m/pub';
 
+// Published doc containing editorials for unknown charities (not in the database)
+const publishedUrlWithUnrecognisedCharities = 'https://docs.google.com/document/d/e/2PACX-1vRk52OOb1-yS3hejnqdeGfjT6m5wIXBYcjVGqaxDwYcpJZVVeefR6IpED8tMb09O_9PIE-c0YFkhpBR/pub';
+
 // Increase default timeout to prevent occasional flaky failures.
 // Note, this must be higher than any specific timeouts set within the tests below, otherwise they have no effect.
 jest.setTimeout(30000);
@@ -84,6 +87,20 @@ describe('Editor dashboard tests', () => {
 		await(page.waitForSelector('div.alert-danger'))
 		const alertMessage = await page.$eval('div.alert', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Malformed URL'));
+	});
+
+	test('Do not import editorials for charities not in the database', async () => {
+		await page.type('[name=editorialsUrl]', publishedUrlWithUnrecognisedCharities);
+		await page.click('[name=importEditorials]');
+
+		// give elastic search time to update
+		await page.waitFor(1000);
+
+		await(page.waitForSelector('div.alert'))
+		const alertMessage = await page.$eval('div.alert', e => e.innerText);
+		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported 0 editorials'));
+
+		// TODO: Test we notify the user which charity editorials were rejected.
 	});
 
 });

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -66,7 +66,7 @@ describe('Editor dashboard tests', () => {
 
 		await(page.waitForSelector('div.alert'))
 		const alertMessage = await page.$eval('div.alert', e => e.innerText);
-		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported editorials'));
+		expect(alertMessage).toEqual(expect.stringContaining('Successfully imported 1 editorials'));
 
 		const editorialsUrlText = await page.$eval('[name=editorialsUrl]', e => e.value);
 		expect (editorialsUrlText).toBe('');
@@ -91,4 +91,5 @@ describe('Editor dashboard tests', () => {
 		const alertMessage = await page.$eval('div.alert', e => e.innerText);
 		expect(alertMessage).toEqual(expect.stringContaining('Malformed URL'));
 	});
+
 });

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -41,6 +41,14 @@ describe('Editor dashboard tests', () => {
 		await page.goto(`${url}#editordashboard`);
 	});
 
+	afterEach(async () => {
+		// dismiss any leftover dialogs
+		await page.evaluate(() => {
+			document.querySelectorAll(".alert-warning > .close").forEach(el => el.click());
+			document.querySelectorAll(".alert-danger > .close").forEach(el => el.click());
+		});
+	});
+
 	test('Import charity editorials from published gdoc', async () => {
 		await page.type('[name=editorialsUrl]', editorialsUrl);
 		await page.click('[name=importEditorials]');

--- a/src/puppeteer-tests/__tests__/editor-dashboard.test.js
+++ b/src/puppeteer-tests/__tests__/editor-dashboard.test.js
@@ -39,6 +39,14 @@ beforeAll(async () => {
 describe('Editor dashboard tests', () => {
 	beforeEach(async () => {
 		await page.goto(`${url}#editordashboard`);
+		// dismiss any leftover dialogs
+		await page.evaluate(() => {
+			document.querySelectorAll(".alert-warning > .close").forEach(el => el.click());
+			document.querySelectorAll(".alert-danger > .close").forEach(el => el.click());
+		});
+		// wait for alert dialog to disappear
+		// (decrease timeout so we fail-fast & get a better error message if it doesn't)
+		await page.waitForSelector('.alert-danger', { hidden: true, timeout: 5000 });
 	});
 
 	afterEach(async () => {
@@ -74,16 +82,13 @@ describe('Editor dashboard tests', () => {
 		expect(charityEditorial).toEqual(expectedEditorial);
 	});
 
-	test('Do not show success alert for a malformed URL', async () => {
+	test('Show error alert for a malformed URL', async () => {
 		await page.type('[name=editorialsUrl]', "malformedURLjckdsljkldjkls");
+
 		await page.click('[name=importEditorials]');
 
-		// give elastic search time to update
-		await page.waitFor(1000);
-
-		await(page.waitForSelector('div.alert'))
+		await(page.waitForSelector('div.alert-danger'))
 		const alertMessage = await page.$eval('div.alert', e => e.innerText);
-		expect(alertMessage).not.toEqual(expect.stringContaining('Successfully imported editorials'));
+		expect(alertMessage).toEqual(expect.stringContaining('Malformed URL'));
 	});
-
 });

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -42,8 +42,9 @@ public class ImportEditorialsDataTaskTest {
                         TEST_URL,
                         ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
 
-        importEditorialsDataTask.run(TEST_URL);
+        int totalImported = importEditorialsDataTask.run(TEST_URL);
 
+        assertEquals(1, totalImported);
         assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
 
@@ -122,8 +123,9 @@ public class ImportEditorialsDataTaskTest {
                                 "charity-one", Collections.singletonList("Charity One Editorial"),
                                 "charity-two", Arrays.asList("Charity Two Editorial", "Second paragraph"))));
 
-        importEditorialsDataTask.run(TEST_URL);
+        int totalImported = importEditorialsDataTask.run(TEST_URL);
 
+        assertEquals(2, totalImported);
         assertEquals("Charity One Editorial", databaseWriter.getCharityRecommendation("charity-one"));
         assertEquals("Charity Two Editorial\n\nSecond paragraph",
                 databaseWriter.getCharityRecommendation("charity-two"));

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -48,6 +48,20 @@ public class ImportEditorialsDataTaskTest {
     }
 
     @Test
+    public void testImportEditorials_singleCharityPascalCase_alreadyInDatabaseAsLowercase() {
+        databaseWriter.upsertCharityRecord(new NGO("doctors-without-borders"));
+
+        fakeDocumentFetcher.setDocumentAtUrl(
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of("Doctors-Without-Borders", Collections.singletonList("Great charity *****"))));
+
+        importEditorialsDataTask.run(TEST_URL);
+
+        assertEquals("Great charity *****", databaseWriter.getCharityRecommendation("doctors-without-borders"));
+    }
+
+    @Test
     public void testImportEditorials_singleCharity_notInDatabase_doesNotImport() {
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -1,6 +1,7 @@
 package org.sogive.data.loader;
 
 import com.google.common.collect.ImmutableMap;
+import com.winterwell.utils.containers.ArrayMap;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Before;
@@ -42,9 +43,9 @@ public class ImportEditorialsDataTaskTest {
                         TEST_URL,
                         ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
 
-        int totalImported = importEditorialsDataTask.run(TEST_URL);
+        ArrayMap result = importEditorialsDataTask.run(TEST_URL);
 
-        assertEquals(1, totalImported);
+        assertEquals(1, result.get("totalImported"));
         assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
     }
 
@@ -69,9 +70,11 @@ public class ImportEditorialsDataTaskTest {
                         TEST_URL,
                         ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
 
-        importEditorialsDataTask.run(TEST_URL);
+        ArrayMap result = importEditorialsDataTask.run(TEST_URL);
 
         assertNull(databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
+        assertEquals(0, result.get("totalImported"));
+        assertEquals(Arrays.asList(TBD_CHARITY_ID), result.get("rejectedIds"));
     }
 
     @Test
@@ -123,7 +126,8 @@ public class ImportEditorialsDataTaskTest {
                                 "charity-one", Collections.singletonList("Charity One Editorial"),
                                 "charity-two", Arrays.asList("Charity Two Editorial", "Second paragraph"))));
 
-        int totalImported = importEditorialsDataTask.run(TEST_URL);
+        ArrayMap result = importEditorialsDataTask.run(TEST_URL);
+        int totalImported = (int) result.get("totalImported");
 
         assertEquals(2, totalImported);
         assertEquals("Charity One Editorial", databaseWriter.getCharityRecommendation("charity-one"));


### PR DESCRIPTION
- [x] Sanitize charity ids so it's ok if they're provided in Pascal-Case in the doc

- [x] Editor Dashboard UI improvements
  - [x] explain about it needing to be a published google doc ending in /pub & how to publish a google doc

  - [x] change wording to 'import' not 'upload'


- [x] Error-handling - for badly formatted google docs / docs containing no editorials - should show message to user, at least showing how many editorials were imported.

- [x] Auth - don't show the dashboard to non-editors