### PR TITLE
Fix money validation error in DonationWizard

### DIFF
--- a/src/js/components/DonationWizard.jsx
+++ b/src/js/components/DonationWizard.jsx
@@ -689,7 +689,7 @@ const PaymentSection = ({path, donation, item, event, paidElsewhere, closeLightb
 	return (<div>
 		<div className="padded-block">
 			<PropControl type="checkbox" path={path} item={donation} prop="hasTip" label={tipLabel} />
-			<PropControl type="Money" path={path} item={donation} prop="tip" min={0}
+			<PropControl type="Money" path={path} item={donation} prop="tip" min={new Money(0)}
 				label={space('Amount', Donation.isRepeating(donation) && '(one-off payment)')} disabled={donation.hasTip===false}
 			/>
 		</div>


### PR DESCRIPTION
This fixes the error seen after passing the GiftAid step in the donation wizard:

![image](https://user-images.githubusercontent.com/1918555/108125991-2a7fdb80-70a1-11eb-9f38-afe37019afc4.png)

However, I still get the following error at the same step:
```
Uncaught Error: assert-failed: ["PaymentWidget.jsx a-match: undefined !~ undefined"]
    at assertFailed (assert.js:41)
    at assert (assert.js:30)
    at assMatch (assert.js:61)
    at PaymentWidget (PaymentWidget.jsx:80)
```
 (I think probably related to what @roscoemcinerney was saying in the GoodLoop chat.)

At least this is a step in the right direction.