### PR TITLE
Set 'name' not 'displayName' for dummy charity on startup

### DIFF
--- a/src/java/org/sogive/data/DBSoGive.java
+++ b/src/java/org/sogive/data/DBSoGive.java
@@ -130,7 +130,7 @@ public class DBSoGive {
 		
 		// Dummy TBD charity
 		NGO ngo = new NGO("tbd");
-		ngo.put("displayName", "TBD: To Be Decided");
+		ngo.put("name", "TBD: To Be Decided");
 		ngo.put("description", "This is a placeholder for people who haven't picked their charity yet.");
 		ESPath draftPath = Dep.get(IESRouter.class).getPath(NGO.class, "tbd", KStatus.DRAFT);
 		ESPath pubPath = Dep.get(IESRouter.class).getPath(NGO.class, "tbd", KStatus.PUBLISHED);


### PR DESCRIPTION
'tbd' is supposed to be a dummy charity that can stand in for a real charity for testing

While the handful of real charities I checked **all** had 'name' set, at least one ('The END Fund') did **not** have displayName set

Therefore it makes sense to make the dummy charity have this 'name' property instead of displayName

(Also, if 'name' is not set then the DonationWizard crashes. What do you think, should DonationWizard handle this edge case? Or do we expect 'name' to always be set? It could fallback to charity id, but for payments I don't know if that would be a valid recipient..)