### PR TITLE
Make the importer tool import draft editorials too

### DIFF
--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -8,10 +8,18 @@ import org.sogive.data.charity.NGO;
  *
  */
 public interface DatabaseWriter {
-    void upsertCharityRecord(NGO ngo);
+
+    enum Status {
+        PUBLISHED,
+        DRAFT,
+        ABSENT
+    }
+
+    void upsertCharityRecord(NGO ngo, Status status);
 
     /**
      * Checks if this charity is published in the database.
+     * @return
      */
-    boolean contains(String charityId);
+    Status contains(String charityId);
 }

--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -15,7 +15,7 @@ public interface DatabaseWriter {
         ABSENT
     }
 
-    void upsertCharityRecord(NGO ngo, Status status);
+    void updateCharityRecord(NGO ngo, Status status);
 
     /**
      * Checks if this charity is published in the database.

--- a/src/java/org/sogive/data/loader/DatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/DatabaseWriter.java
@@ -1,5 +1,6 @@
 package org.sogive.data.loader;
 
+import com.winterwell.data.KStatus;
 import org.sogive.data.charity.NGO;
 
 /**
@@ -9,17 +10,15 @@ import org.sogive.data.charity.NGO;
  */
 public interface DatabaseWriter {
 
-    enum Status {
-        PUBLISHED,
-        DRAFT,
-        ABSENT
-    }
-
-    void updateCharityRecord(NGO ngo, Status status);
+    /**
+     * Updates the charity's properties with the given status in the database.
+     */
+    void updateCharityRecord(NGO ngo, KStatus status);
 
     /**
-     * Checks if this charity is published in the database.
-     * @return
+     * Checks this charity's status in the database.
+     *
+     * @return PUBLISHED, DRAFT or ABSENT (if neither PUBLISHED or DRAFT).
      */
-    Status contains(String charityId);
+    KStatus contains(String charityId);
 }

--- a/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
@@ -11,28 +11,28 @@ import org.sogive.data.charity.SoGiveConfig;
 
 public class ElasticSearchDatabaseWriter implements DatabaseWriter {
     @Override
-    public void updateCharityRecord(NGO ngo, Status status) {
+    public void updateCharityRecord(NGO ngo, KStatus KStatus) {
         String charityId = ngo.getId();
         ESPath draftPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.DRAFT);
-        if (status == Status.DRAFT) {
+        if (KStatus == KStatus.DRAFT) {
             AppUtils.doSaveEdit(draftPath, new JThing(ngo), null);
         }
-        if (status == Status.PUBLISHED) {
+        if (KStatus == KStatus.PUBLISHED) {
             ESPath pubPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.PUBLISHED);
             AppUtils.doPublish(new JThing(ngo), draftPath, pubPath);
         }
     }
 
     @Override
-    public Status contains(String charityId) {
+    public KStatus contains(String charityId) {
         ESPath publishedPath = Dep.get(SoGiveConfig.class).getPath(null, NGO.class, charityId, KStatus.PUBLISHED);
         if (AppUtils.get(publishedPath, NGO.class) != null) {
-            return Status.PUBLISHED;
+            return KStatus.PUBLISHED;
         }
         ESPath draftPath = Dep.get(SoGiveConfig.class).getPath(null, NGO.class, charityId, KStatus.DRAFT);
         if (AppUtils.get(draftPath, NGO.class) != null) {
-            return Status.DRAFT;
+            return KStatus.DRAFT;
         }
-        return Status.ABSENT;
+        return KStatus.ABSENT;
     }
 }

--- a/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
+++ b/src/java/org/sogive/data/loader/ElasticSearchDatabaseWriter.java
@@ -11,7 +11,7 @@ import org.sogive.data.charity.SoGiveConfig;
 
 public class ElasticSearchDatabaseWriter implements DatabaseWriter {
     @Override
-    public void upsertCharityRecord(NGO ngo, Status status) {
+    public void updateCharityRecord(NGO ngo, Status status) {
         String charityId = ngo.getId();
         ESPath draftPath = Dep.get(IESRouter.class).getPath(NGO.class, charityId, KStatus.DRAFT);
         if (status == Status.DRAFT) {

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -57,14 +57,15 @@ public class ImportEditorialsDataTask {
 		List<String> rejectedIds = new ArrayList<>();
 		for (Editorial editorial : editorials) {
 			String charityId = editorial.getCharityId();
+			DatabaseWriter.Status status = database.contains(charityId);
 			// If it's not already in the charity database, we don't want to insert it.
-			if (!database.contains(charityId)) {
+			if (status == DatabaseWriter.Status.ABSENT) {
 				rejectedIds.add(charityId);
 				continue;
 			}
 			NGO ngo = new NGO(charityId);
 			ngo.put("recommendation", editorial.getEditorialText());
-			database.upsertCharityRecord(ngo);
+			database.upsertCharityRecord(ngo, status);
 			count++;
 		}
 		return new ArrayMap("totalImported", count, "rejectedIds", rejectedIds);

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -65,7 +65,7 @@ public class ImportEditorialsDataTask {
 			}
 			NGO ngo = new NGO(charityId);
 			ngo.put("recommendation", editorial.getEditorialText());
-			database.upsertCharityRecord(ngo, status);
+			database.updateCharityRecord(ngo, status);
 			count++;
 		}
 		return new ArrayMap("totalImported", count, "rejectedIds", rejectedIds);

--- a/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
+++ b/src/java/org/sogive/data/loader/ImportEditorialsDataTask.java
@@ -1,5 +1,6 @@
 package org.sogive.data.loader;
 
+import com.winterwell.data.KStatus;
 import com.winterwell.utils.Utils;
 import com.winterwell.utils.containers.ArrayMap;
 import com.winterwell.utils.log.Log;
@@ -57,9 +58,9 @@ public class ImportEditorialsDataTask {
 		List<String> rejectedIds = new ArrayList<>();
 		for (Editorial editorial : editorials) {
 			String charityId = editorial.getCharityId();
-			DatabaseWriter.Status status = database.contains(charityId);
+			KStatus status = database.contains(charityId);
 			// If it's not already in the charity database, we don't want to insert it.
-			if (status == DatabaseWriter.Status.ABSENT) {
+			if (status == KStatus.ABSENT) {
 				rejectedIds.add(charityId);
 				continue;
 			}

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -1,6 +1,7 @@
 package org.sogive.data.loader;
 
 import com.google.common.collect.ImmutableMap;
+import com.winterwell.data.KStatus;
 import com.winterwell.utils.containers.ArrayMap;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -36,7 +37,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_alreadyPublishedInDatabase() {
-        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), KStatus.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -51,7 +52,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_alreadyInDraftInDatabase_updatesEditorialButDoesNotPublish() {
-        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.DRAFT);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), KStatus.DRAFT);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -62,12 +63,12 @@ public class ImportEditorialsDataTaskTest {
 
         assertEquals(1, result.get("totalImported"));
         assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
-        assertEquals(DatabaseWriter.Status.DRAFT, databaseWriter.contains(TBD_CHARITY_ID));
+        assertEquals(KStatus.DRAFT, databaseWriter.contains(TBD_CHARITY_ID));
     }
 
     @Test
     public void testImportEditorials_singleCharityPascalCase_alreadyInDatabaseAsLowercase() {
-        databaseWriter.updateCharityRecord(new NGO("doctors-without-borders"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("doctors-without-borders"), KStatus.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -95,7 +96,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorial_alreadyInDatabase() {
-        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), KStatus.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -108,7 +109,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2_alreadyInDatabase() {
-        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), KStatus.PUBLISHED);
 
         Document document = Document.createShell(TEST_URL);
 
@@ -133,8 +134,8 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_multipleCharities_alreadyInDatabase() {
-        databaseWriter.updateCharityRecord(new NGO("charity-one"), DatabaseWriter.Status.PUBLISHED);
-        databaseWriter.updateCharityRecord(new NGO("charity-two"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("charity-one"), KStatus.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("charity-two"), KStatus.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -194,7 +195,7 @@ public class ImportEditorialsDataTaskTest {
         }
 
         @Override
-        public void updateCharityRecord(NGO ngo, Status status) {
+        public void updateCharityRecord(NGO ngo, KStatus status) {
             switch (status) {
                 case DRAFT:
                     draftCharityRecords.put(ngo.getId(), ngo);
@@ -207,14 +208,14 @@ public class ImportEditorialsDataTaskTest {
         }
 
         @Override
-        public Status contains(String charityId) {
+        public KStatus contains(String charityId) {
             if (publishedCharityRecords.containsKey(charityId)) {
-                return Status.PUBLISHED;
+                return KStatus.PUBLISHED;
             }
             if (draftCharityRecords.containsKey(charityId)) {
-                return Status.DRAFT;
+                return KStatus.DRAFT;
             }
-            return Status.ABSENT;
+            return KStatus.ABSENT;
         }
 
         public String getCharityRecommendation(String charityId) {

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -36,7 +36,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_alreadyPublishedInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -51,7 +51,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_alreadyInDraftInDatabase_updatesEditorialButDoesNotPublish() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.DRAFT);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.DRAFT);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -67,7 +67,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharityPascalCase_alreadyInDatabaseAsLowercase() {
-        databaseWriter.upsertCharityRecord(new NGO("doctors-without-borders"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("doctors-without-borders"), DatabaseWriter.Status.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -95,7 +95,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorial_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -108,7 +108,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
 
         Document document = Document.createShell(TEST_URL);
 
@@ -133,8 +133,8 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_multipleCharities_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO("charity-one"), DatabaseWriter.Status.PUBLISHED);
-        databaseWriter.upsertCharityRecord(new NGO("charity-two"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("charity-one"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.updateCharityRecord(new NGO("charity-two"), DatabaseWriter.Status.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -194,7 +194,7 @@ public class ImportEditorialsDataTaskTest {
         }
 
         @Override
-        public void upsertCharityRecord(NGO ngo, Status status) {
+        public void updateCharityRecord(NGO ngo, Status status) {
             switch (status) {
                 case DRAFT:
                     draftCharityRecords.put(ngo.getId(), ngo);

--- a/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
+++ b/test/java/org/sogive/data/loader/ImportEditorialsDataTaskTest.java
@@ -35,8 +35,8 @@ public class ImportEditorialsDataTaskTest {
     }
 
     @Test
-    public void testImportEditorials_singleCharity_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
+    public void testImportEditorials_singleCharity_alreadyPublishedInDatabase() {
+        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -50,8 +50,24 @@ public class ImportEditorialsDataTaskTest {
     }
 
     @Test
+    public void testImportEditorials_singleCharity_alreadyInDraftInDatabase_updatesEditorialButDoesNotPublish() {
+        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.DRAFT);
+
+        fakeDocumentFetcher.setDocumentAtUrl(
+                generateDocumentContainingCharityEditorials(
+                        TEST_URL,
+                        ImmutableMap.of(TBD_CHARITY_ID, Collections.singletonList(TBD_CHARITY_EDITORIAL_TEXT))));
+
+        ArrayMap result = importEditorialsDataTask.run(TEST_URL);
+
+        assertEquals(1, result.get("totalImported"));
+        assertEquals(TBD_CHARITY_EDITORIAL_TEXT, databaseWriter.getCharityRecommendation(TBD_CHARITY_ID));
+        assertEquals(DatabaseWriter.Status.DRAFT, databaseWriter.contains(TBD_CHARITY_ID));
+    }
+
+    @Test
     public void testImportEditorials_singleCharityPascalCase_alreadyInDatabaseAsLowercase() {
-        databaseWriter.upsertCharityRecord(new NGO("doctors-without-borders"));
+        databaseWriter.upsertCharityRecord(new NGO("doctors-without-borders"), DatabaseWriter.Status.PUBLISHED);
 
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
@@ -79,7 +95,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorial_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
+        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -92,7 +108,7 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_singleCharity_multiParagraphEditorialContainingH2_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID));
+        databaseWriter.upsertCharityRecord(new NGO(TBD_CHARITY_ID), DatabaseWriter.Status.PUBLISHED);
 
         Document document = Document.createShell(TEST_URL);
 
@@ -117,8 +133,8 @@ public class ImportEditorialsDataTaskTest {
 
     @Test
     public void testImportEditorials_multipleCharities_alreadyInDatabase() {
-        databaseWriter.upsertCharityRecord(new NGO("charity-one"));
-        databaseWriter.upsertCharityRecord(new NGO("charity-two"));
+        databaseWriter.upsertCharityRecord(new NGO("charity-one"), DatabaseWriter.Status.PUBLISHED);
+        databaseWriter.upsertCharityRecord(new NGO("charity-two"), DatabaseWriter.Status.PUBLISHED);
         fakeDocumentFetcher.setDocumentAtUrl(
                 generateDocumentContainingCharityEditorials(
                         TEST_URL,
@@ -168,27 +184,47 @@ public class ImportEditorialsDataTaskTest {
 
     private static class InMemoryDatabaseWriter implements DatabaseWriter {
 
-        private final Map<String, NGO> charityRecords;
+        private final Map<String, NGO> publishedCharityRecords;
+
+        private final Map<String, NGO> draftCharityRecords;
 
         private InMemoryDatabaseWriter() {
-            charityRecords = new HashMap<>();
+            publishedCharityRecords = new HashMap<>();
+            draftCharityRecords = new HashMap<>();
         }
 
         @Override
-        public void upsertCharityRecord(NGO ngo) {
-            charityRecords.put(ngo.getId(), ngo);
+        public void upsertCharityRecord(NGO ngo, Status status) {
+            switch (status) {
+                case DRAFT:
+                    draftCharityRecords.put(ngo.getId(), ngo);
+                    return;
+                case PUBLISHED:
+                    publishedCharityRecords.put(ngo.getId(), ngo);
+                    return;
+                default:
+            }
         }
 
         @Override
-        public boolean contains(String charityId) {
-            return charityRecords.containsKey(charityId);
+        public Status contains(String charityId) {
+            if (publishedCharityRecords.containsKey(charityId)) {
+                return Status.PUBLISHED;
+            }
+            if (draftCharityRecords.containsKey(charityId)) {
+                return Status.DRAFT;
+            }
+            return Status.ABSENT;
         }
 
         public String getCharityRecommendation(String charityId) {
-            if (charityRecords.get(charityId) == null) {
-                return null;
+            if (publishedCharityRecords.get(charityId) != null) {
+                return (String) publishedCharityRecords.get(charityId).get("recommendation");
             }
-            return (String) charityRecords.get(charityId).get("recommendation");
+            if (draftCharityRecords.get(charityId) != null) {
+                return (String) draftCharityRecords.get(charityId).get("recommendation");
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
This commit makes the importer tool still import editorials for charities which are only in draft, without publishing them.

(This was a request from Sanjay / Gergo, since a lot of the new editorials are for charities which are not published yet).