### PR TITLE
Update the impact ratings and confidence levels

### DIFF
--- a/src/js/C.js
+++ b/src/js/C.js
@@ -34,14 +34,17 @@ Roles.defineRole(C.ROLES.goodlooper, [C.CAN.edit, C.CAN.publish, C.CAN.goodloop]
 // Taken from: http://emailregex.com/
 C.emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-C.IMPACT_VALUES = new Enum("high medium low very-low more-info-needed");
+C.IMPACT_VALUES = new Enum("high medium slightly-low low more-info-needed-promising more-info-needed too-rich very-low");
 /**
  * Lowercase and do not change! - the labels are also used as css class names!
  */
 C.IMPACT_LABEL4VALUE = {
 	"high": "gold",
 	"medium": "silver",
-	"low": "bronze",
-	"very-low": "do not donate",
-	"more-info-needed": "more information needed"
+	"slightly-low": "bronze",
+	"low": "not recommended",
+	"more-info-needed-promising": "more information needed (promising)",
+	"more-info-needed": "more information needed",
+	"too-rich": "too rich",
+	"very-low": "do not donate"
 };

--- a/src/js/components/SearchPage.jsx
+++ b/src/js/components/SearchPage.jsx
@@ -336,7 +336,7 @@ const ImpactBadge = ({charity}) => {
 	let help = {
 		high: 'Gold: a high impact charity with solid data',
 		medium: 'Silver: an effective charity',
-		low: 'Bronze: Either the impact or the impact measurement/reporting could be better',
+		low: 'Not Recommended: we believe the charity does less good than our Gold-rated charities',
 	}[charity.impact];
 	return <span className={'impact-rating pull-right text-'+label} title={help}><Misc.Icon fa='award' /> {label}</span>;
 };

--- a/src/js/components/editor/SimpleEditCharityPage.jsx
+++ b/src/js/components/editor/SimpleEditCharityPage.jsx
@@ -25,6 +25,13 @@ import { getDataItem } from '../../base/plumbing/Crud';
 
 const CONFIDENCE_VALUES = new Enum("high medium low very-low");
 
+const CONFIDENCE_LABEL4VALUE = {
+	"high": "firm",
+	"medium": "tentative",
+	"low": "low [not being used]",
+	"very-low": "very low [not being used]"
+};
+
 /**
  * HACK flag for simple vs advanced editor -- lets us mix in some advanced controls here.
  */
@@ -140,6 +147,7 @@ const EditorialEditor = ({charity}) => {
 		<EditField item={charity} field="confidence"
 			type="select"
 			options={CONFIDENCE_VALUES.values}
+			labels={CONFIDENCE_LABEL4VALUE}
 			label="Overall Confidence"
 			help="How confident are we that the charity will achieve its aims? This is often low for even good lobbying charities."
 		/>


### PR DESCRIPTION
Hello again, Sanjay requested this small change for analysts implementing the new rating system on Saturday. More context: https://docs.google.com/document/d/18pekFtO7mJzjpvvFsl45B9Z4x30UFErkff2tYLxTvmE/edit

Introduced 3 new impact ratings
- more-info-needed-promising
- too-rich
- slightly-low

Slightly-low is now mapped to Bronze and low is now mapped to Not Recommended.
This means charities that were previously displayed as Bronze will now display as Not Recommended.

Also, added labels to confidence values (high -> firm, medium -> tentative), deprecating low and very-low.

Co-authored-by: Anita W <anitawoodruff@users.noreply.github.com>