### PR TITLE
Change label to 'not recommended, too rich' for very-low impact

### DIFF
--- a/src/js/C.js
+++ b/src/js/C.js
@@ -46,5 +46,5 @@ C.IMPACT_LABEL4VALUE = {
 	"more-info-needed-promising": "more information needed (promising)",
 	"more-info-needed": "more information needed",
 	"too-rich": "too rich",
-	"very-low": "do not donate"
+	"very-low": "not recommended, too rich"
 };

--- a/src/js/components/SearchPage.jsx
+++ b/src/js/components/SearchPage.jsx
@@ -329,10 +329,10 @@ const ImpactBadge = ({charity}) => {
 	if ( ! NGO.isReady(charity)) return null;
 	if (NGO.isHighImpact(charity)) charity.impact='high'; // old data HACK
 	if ( ! charity.impact || charity.impact==='more-info-needed') return null;
-	if (charity.impact==='very-low') {
-		return <span className='impact-rating pull-right text-warning' title='We suggest avoiding this charity'><Misc.Icon fa='times' /> dubious impact</span>;
-	}
 	const label = C.IMPACT_LABEL4VALUE[charity.impact];
+	if (charity.impact==='very-low') {
+		return <span className='impact-rating pull-right text-warning' title='We suggest avoiding this charity'><Misc.Icon fa='times' /> {label}</span>;
+	}
 	let help = {
 		high: 'Gold: a high impact charity with solid data',
 		medium: 'Silver: an effective charity',


### PR DESCRIPTION
As per the [new ratings system](https://docs.google.com/document/d/18pekFtO7mJzjpvvFsl45B9Z4x30UFErkff2tYLxTvmE/edit), this should be 'not recommended, too rich' in the editor, instead of 'do not donate'.

In search results it was displaying as "dubious impact", but spoke to Sanjay about this in our last meeting and he thinks it should be the same as what appears in the editor. So fixed this to use the editor label, same as the other ratings.

Here is a screenshot of what it looks like now in search results after editing a charity's impact to "not recommended, too rich", including hover text:

![not-recommended-too-rich](https://user-images.githubusercontent.com/1918555/114859542-ce0c1480-9de2-11eb-841e-99f76581ff3f.png)
