### PR TITLE
Update navbar styling to be closer to mocks

### DIFF
--- a/src/js/C.js
+++ b/src/js/C.js
@@ -15,7 +15,6 @@ C.app = {
 	service: "sogive",
 	logo: "/img/SoGive-Light-70px.png",
 	website: "https://sogive.org",
-	homeLogo: "/img/logo-white-sm.png",
 	facebookAppId: "1847521215521290",
 	privacyPolicy: 'https://sogive.org/privacy-policy.html',
 	version: {app: '1.0.1'}

--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -97,6 +97,8 @@ const MainDiv = () => {
 	return (<MainDivBase
 		pageForPath={PAGES}
 		navbarPages={navbarPagesFn}
+		navbarDarkTheme={false}
+		navbarBackgroundColour='white'
 		// securityCheck: ({page}) => throw error / return true
 		// SecurityFailPage: ?JSX
 		defaultPage='search'

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -25,17 +25,18 @@
 	height: auto !important;
 }
 
-#navbar {
-	background-color: @colour-03;
-	font-size: 1em;
+.navbar .navbar-nav .nav-item {
+	padding: 15px;
 }
 
-.navbar-inverse {
-	background-color: @colour-03;
+.navbar .navbar-nav .nav-item .nav-link {
+	color: @dark-grey;
+	font-size: 16px;
+	font-weight: bold
 }
 
-.navbar-inverse .navbar-nav>.active>a, .navbar-inverse .navbar-nav>.active>a:focus, .navbar-inverse .navbar-nav>.active>a:hover {
-	background-color: @colour-03;
+.navbar .navbar-nav .nav-item.active .nav-link {
+	color: @primary-blue;
 }
 
 .messagebar {

--- a/src/style/positioning.less
+++ b/src/style/positioning.less
@@ -4,7 +4,7 @@
 
 // FIXME Document this!
 
-@navbar-height: 75px;
+@navbar-height: 64px;
 @bs-column-padding: 15px;
 
 @band-1-height: 30px;


### PR DESCRIPTION
This gets us quite a bit closer to the mocks, though there's still work to be done:

![image](https://user-images.githubusercontent.com/1918555/123544013-2ea3c000-d749-11eb-993e-ad5839d672ba.png)

TODO in future PRs:
- Highlight links on hover (? - no mocks for this)
- Underline the selected page in blue to match mocks (if this is easy using CSS)
- Update which pages are linked to (to non-app pages) 
  - HOME, ABOUT, CONTACT, and FAQ
	- bit worried this will be complicated since code assumes they are all app pages right now, but haven't tried to actually change it yet
- Remove the account login dropdown (? see discussion points below)
- Add search widget to top-bar - Aishah might take this next time
- Align navbar links to the right hand side, against the search box (if easy with CSS)

