### PR TITLE
Fixing the text logo placeholder overflow

### DIFF
--- a/src/js/components/SearchPage.jsx
+++ b/src/js/components/SearchPage.jsx
@@ -433,31 +433,23 @@ const SearchResult = ({ item, CTA, onPick }) => {
             }
             data-id={cid}
         >
-            <a
-                href={charityUrl}
-                onClick={onClick}
-                className="logo col-md-2 col-xs-4"
-            >
-                {item.logo ? (
+            {item.logo && (
+                <a
+                    href={charityUrl}
+                    onClick={onClick}
+                    className="logo col-md-2 col-xs-4"
+                >
                     <img
                         className="charity-logo"
                         src={NGO.logo(item)}
                         alt={`Logo for ${charityName}`}
                     />
-                ) : (
-                    <div
-                        className={`charity-logo-placeholder ${
-                            longName ? "long-name" : ""
-                        }`}
-                    >
-                        {charityName}
-                    </div>
-                )}
             </a>
+            )}
             <a
                 href={charityUrl}
                 onClick={onClick}
-                className="text-summary std-padding col-md-4 col-xs-8"
+                className="text-summary std-padding searchpg-flex-grow col-md-4 col-xs-8"
             >
                 <h3 className="name charity-card-title">{charityName}</h3>
                 <p className="description">

--- a/src/style/SearchPage.less
+++ b/src/style/SearchPage.less
@@ -92,6 +92,10 @@
 			color: #262741
 		}
 	}
+	.searchpg-flex-grow {
+		flex: 1 0 33.333333%;
+		max-width: 50%;
+	}
 	.impact {
 		border-left: solid 1px @light-grey;
 		h4 {


### PR DESCRIPTION
Solution to this was to remove the placeholders completely and expand the column when a logo is unavailable. 

**How it looks now:**
![image](https://user-images.githubusercontent.com/26288170/126064672-883a3685-735e-48fc-82df-c65520cdc972.png)

The logo not showing due to a broken link will still be visible.

**How it looked before:**
![overflowing text](https://user-images.githubusercontent.com/26288170/126064649-542a90f5-4def-4eb3-8795-abe760c5438b.png)

@anitawoodruff 