### PR TITLE
Fix Impact Calculator bug

### DIFF
--- a/src/js/components/ImpactCalculator.jsx
+++ b/src/js/components/ImpactCalculator.jsx
@@ -112,7 +112,7 @@ class ImpactCalculator extends Component {
 		return (
 			<div className='donation-impact std-border std-padding std-box-shadow '>
 				<button onClick={donationDown} className='donation-down'>-</button>
-				<Misc.PropControl type='Money' prop='amount' path={formPath} changeCurrency={false} />
+				<Misc.PropControl type='Money' prop='amount' path={formPath} changeCurrency={false} rawValue={null}/>
 				<button onClick={donationUp} className='donation-up'>+</button>
 				<div className='will-fund div-section-larger-text'>can fund</div>
 				<DonationOutput impact={impact} charity={charity} />


### PR DESCRIPTION
Previously, after the user manually updated the impact calculator, the raw value they typed would always be displayed, regardless of pressing + / - buttons. You can observe this behaviour at test.sogive.org.

Now, the impact calculator behaves correctly - it updates based on both user input and increment/decrement buttons.

Unclear to me exactly how this change fixes it - I think it's something to do with this comment in PropControl.jsx: 

```
	// What is rawValue?
	// It is the value as typed by the user. This allows the user to move between invalid values, by keeping a copy of their raw input.
	// NB: Most PropControl types ignore rawValue. Those that use it should display rawValue.
	// Warning: rawValue === undefined/null means "use storeValue". BUT rawValue === "" means "show a blank"
``` 