### PR TITLE
Hide DonateButton when charity.noPublicDonations is true

### DIFF
--- a/src/js/components/DonationWizard.jsx
+++ b/src/js/components/DonationWizard.jsx
@@ -52,6 +52,9 @@ const getWidgetProp = (forItem, prop) => (
  * NB: We can have several DonateButtons, but only one modal form
  */
 const DonateButton = ({item, paidElsewhere, isOutlined = false, isLarge = true, ...props}) => {
+	if (NGO.noPublicDonations(item)) {
+		return null;
+	}
 	assert(item && getId(item), "DonationWizard.js - DonateButton: no item "+item);
 
 	// no donations to draft fundraisers or charities


### PR DESCRIPTION
We already hide the impact calculator on the CharityPage when noPublicDonations is true, and display the stated reason why. This change also hides the Donate Button, both from CharityPage and SearchResults.