### PR TITLE
Add filteredResources entry to .project file

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1630748238196</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
- Whenever you open the `winterwell/sogive-app` directory in VSCode, then, if you have "Extension Pack for Java" installed, VSCode will generate these changes to the `.project` file that Eclipse also uses. 

- I couldn't find an explanation for why exactly it wants to ignore these resources, but it looks to me like sensible things to keep hidden when viewing in an IDE (node_module files, .git files, and files generated by the Java language server).

- I checked that the project still opens fine and runs from Eclipse with these changes. 

- An alternative would be to add `.project` to the `gitignore`, but then new contributors wouldn't be able to import directly as an Eclipse project.