### PR TITLE
Display a search widget in the navigation bar

### DIFF
--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import Login from '../base/youagain';
-import { Container } from 'reactstrap';
+import { Button } from 'reactstrap';
 import _ from 'lodash';
 
 // Plumbing
-import DataStore from '../base/plumbing/DataStore';
+import DataStore, { getValue } from '../base/plumbing/DataStore';
 import Roles from '../base/Roles';
 import CRUD from '../base/plumbing/Crud';
 import C from '../C';
@@ -14,6 +14,9 @@ import Messaging from '../base/plumbing/Messaging';
 import MessageBar from '../base/components/MessageBar';
 import NavBar from '../base/components/NavBar';
 import LoginWidget, { setShowLogin } from '../base/components/LoginWidget';
+import PropControl from '../base/components/PropControl';
+// Components
+import { FieldClearButton } from './SearchPage';
 // Pages
 import DashboardPage from './DashboardPage';
 import SearchPage from './SearchPage';
@@ -84,6 +87,9 @@ const EXTERNAL_PAGE_LINKS = {
 	faq: "https://sogive.org/faq.html"
 }
 
+const SEARCH_QUERY_DATASTORE_PATH = ['widget', 'navbarsearch'];
+const SEARCH_QUERY_DATASTORE_PROP = "search_query";
+
 // NB: MainDivBase does this too, but not until after getRoles is called below
 Login.app = C.app.service;
 
@@ -102,6 +108,48 @@ const navbarPagesFn = () => {
 	return [...pages];
 };
 
+const SearchWidget = () => {
+    const searchIcon = <Misc.Icon prefix="fas" fa="search" />;
+
+    const searchQuery = getValue([...SEARCH_QUERY_DATASTORE_PATH, SEARCH_QUERY_DATASTORE_PROP]);
+    const onSubmit = (e) => {
+        DataStore.setUrlValue("q", searchQuery);
+    };
+
+    const url = '#search?q=' + DataStore.getUrlValue('q');
+    const submitButton = (
+        <a href={url}>
+            <Button
+                type="submit"
+                onClick={onSubmit}
+                color="primary"
+                className="sogive-search-box"
+            >
+                Search
+            </Button>
+        </a>
+    );
+
+    return (
+        // Unable to use a Form here because it prevents the submitButton navigating to the
+        // Search page when the user is on the Charity page (the PropControl prop gets appended
+        // to the URL before the '#search' page anchor). (Unfortunately this means the user
+        // can't press 'Enter' in the textbox to search, they must click the submit button.)
+        <div className="navbar-search-widget ml-auto">
+            <PropControl
+                path={SEARCH_QUERY_DATASTORE_PATH}
+                prop={SEARCH_QUERY_DATASTORE_PROP}
+                type="search"
+                placeholder="Enter a charity's name"
+                prepend={searchIcon}
+                append={submitButton}
+                size="lg"
+            />
+            <FieldClearButton />
+        </div>
+    );
+}
+
 /**
 	Top-level: tabs
 */
@@ -119,6 +167,7 @@ const MainDiv = () => {
 		defaultPage='search'
 		fullWidthPages={['search']}
 		navbarExternalLinks={EXTERNAL_PAGE_LINKS}
+		navbarChildren={<SearchWidget/>}
 	/>);
 };
 

--- a/src/js/components/SearchPage.jsx
+++ b/src/js/components/SearchPage.jsx
@@ -139,7 +139,7 @@ const SearchForm = ({ q, status }) => {
     );
 }; //./SearchForm
 
-const FieldClearButton = ({ onClick }) => (
+export const FieldClearButton = ({ onClick }) => (
     <span className="field-clear-button visible-xs-block" onClick={onClick}>
         <Misc.Icon prefix="fas" fa="remove-circle" />
     </span>

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -28,6 +28,14 @@
 	padding: 15px;
 }
 
+.navbar-search-widget {
+	padding-top: 15px;
+	.sogive-search-box {
+		padding-top: 10px!important;
+		padding-bottom: 10px!important;
+	}
+}
+
 .navbar .navbar-nav .nav-item .nav-link {
 	color: @dark-grey;
 	font-size: 16px;


### PR DESCRIPTION
Here is how it looks now:

![Screenshot from 2021-09-04 15-58-43](https://user-images.githubusercontent.com/1918555/132098910-4e79888a-3cfc-43dc-8f78-91a07e27a2ec.png)

Searching with it now works! :D it took me & @aissshah a lot of fiddling around, trying to understand PropControl and DataStore to get it to work.

I'm not super happy with it still, since the only way we got it working was to get rid of the 'Form' element and give the submit button a dynamically-generated anchor link which appends the query parameter. The lack of Form means that pressing 'enter' from the text box no longer works to perform the search. Also typing in it is quite laggy - and I couldn't use PropControl `fast` property because it wouldn't always get the up-to-date query parameter when pressing Search.

I think the solution may be to get rid of the PropControl and use a standard Input Text. Either that or stop using an anchor tag to make the button navigate to the Search page (navigate programmatically instead??).

Not sure which was best or how exactly to do the above, so left it like this for now. Let me know what you think / edit as you see fit, of course.

