### PR TITLE
feature/2021-09/navbar-search-tweak

### DIFF
--- a/src/style/buttons.less
+++ b/src/style/buttons.less
@@ -14,6 +14,13 @@
 	.btn-lg {
 		border-radius: 12px;
 	}
+	/* switch off rounding for input appends; copy paste from BS 'cos we changed border-radius above */
+	.input-group>.input-group-append>.btn, 
+	.input-group>.input-group-prepend:first-child>.btn:not(:first-child), 
+	.input-group>.input-group-prepend:not(:first-child)>.btn {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
 
 	.btn-round {
 		// Border-radius can't overlap, so it gets clamped to the largest non-overlapping value - giving us semicircular ends


### PR DESCRIPTION
Hello @anitawoodruff and @aissshah

Thanks for adding this nice widget! I saw Anita's comments re issues with Form.
The problem was setting a url parameter (`q`) without altering the path to ensure it's on `search`. We have a utility function `modifyHash` which handles this -- I've put that in.

Re. PropControl vs Input + useState -- PropControl is best for when the state is shared with other widgets, or if the state should persist across the widget potentially being scrapped and recreated.
In this case, we have purely local state, so Input + useState is better. 

Finally, I tweaked the design sightly to be less large and loud, and switched the icon from font-awesome to unicode. NB: I'd like to remove font-awesome altogether for a slight but noticeable speed boost on loading.

Dan