### PR TITLE
feature/2021-11/track-stray-donation

### DIFF
--- a/src/java/org/sogive/server/payment/StripePaymentIntentServlet.java
+++ b/src/java/org/sogive/server/payment/StripePaymentIntentServlet.java
@@ -8,6 +8,7 @@ import com.stripe.model.PaymentIntent;
 import com.stripe.param.PaymentIntentCreateParams;
 import com.stripe.param.PaymentIntentUpdateParams;
 import com.winterwell.utils.log.Log;
+import com.winterwell.utils.web.WebUtils;
 import com.winterwell.utils.web.WebUtils2;
 import com.winterwell.web.ajax.JsonResponse;
 import com.winterwell.web.app.IServlet;
@@ -43,19 +44,25 @@ public class StripePaymentIntentServlet implements IServlet {
 		String desc = state.get("description");
 		if (desc == null && state.get("basket") != null) {
 			desc = "basket " + state.get("basket");
-		}
+		} else if (desc==null) desc = "";
+		desc += " server:"+WebUtils.hostname(); // debug 2021-09-06 stray donation - was it from a test server?
 
 		try {
 			PaymentIntent intent;
 
 			if (oldId != null) {
 				intent = PaymentIntent.retrieve(oldId);
-				PaymentIntentUpdateParams params = PaymentIntentUpdateParams.builder().setAmount(amt).build();
+				PaymentIntentUpdateParams params = PaymentIntentUpdateParams.builder()
+						.setAmount(amt)
+						.build();
 				intent = intent.update(params);
 			} else {
 				// See https://stripe.com/docs/api/payment_intents/create
-				PaymentIntentCreateParams params = PaymentIntentCreateParams.builder().setAmount(amt)
-						.setDescription(desc).setCurrency("gbp").addPaymentMethodType("card").build();
+				PaymentIntentCreateParams params = PaymentIntentCreateParams.builder()
+						.setAmount(amt)
+						.setDescription(desc)
+						.setCurrency("gbp")
+						.addPaymentMethodType("card").build();
 				intent = PaymentIntent.create(params);
 			}
 

--- a/src/java/org/sogive/server/payment/StripeWebhookServlet.java
+++ b/src/java/org/sogive/server/payment/StripeWebhookServlet.java
@@ -18,11 +18,12 @@ public class StripeWebhookServlet implements IServlet {
 
 	public void process(WebRequest _state) throws Exception {
 		this.state = _state;
+		Log.d("StripeWebhookServlet", _state);
 		// Retrieve the request's body and parse it as JSON
 		Event eventJson = ApiResource.GSON.fromJson(state.getPostBody(), Event.class);
-		Log.d("stripe", "json: " + state.getPostBody());
+		Log.d("StripeWebhookServlet", "json: " + state.getPostBody());
 		// Do something with eventJson??
-		Log.d("stripe", eventJson.getType() + " " + eventJson.getData());
+		Log.d("StripeWebhookServlet", eventJson.getType() + " " + eventJson.getData());
 	}
 
 }


### PR DESCRIPTION
On 2021-09-05 a user made a repeat donation to AMF. That all looks fine.

Then on 2021-09-06 the same user made what looks like the same repeat donation.

Both show as payments in Stripe

BUT 
The app.sogive.org server logs have no record of the 2nd donation -- until Stripe calls a webhook to mark it as complete!

Theory: The 2nd donation was made by some other server -- a local or test server for some reason running with a copy of some real data as part of some debugging or testing.

SO
This PR adds server-name info to what we send to Stripe, and an assert in StripePlugin to block non-production servers from taking real payments.
