### PR TITLE
Change all uses of Misc.PropControl to PropControl

### DIFF
--- a/src/js/components/AccountPage.jsx
+++ b/src/js/components/AccountPage.jsx
@@ -8,6 +8,7 @@ import DataStore from '../base/plumbing/DataStore';
 import ServerIO from '../plumbing/ServerIO';
 import Roles from '../base/Roles';
 import Misc from '../base/components/Misc';
+import PropControl from '../base/components/PropControl';
 import GiftAidForm from './GiftAidForm';
 import Transfer from '../base/data/Transfer';
 import {LoginLink} from '../base/components/LoginWidget';
@@ -77,7 +78,7 @@ const UploadCredit = () => {
 	return (<Misc.Card title='Upload Credit'>
 		{pvCredits.value? pvCredits.value.hits.map(transfer => <div key={transfer.id}><Misc.Money amount={transfer.amount} /> to {transfer.to}</div>) : null}
 		<p>HACK: please paste 2-column csv text below, with the headers <code>Email, Credit</code></p>
-		<Misc.PropControl path={path} prop='csv' label='CSV' type='textarea' />
+		<PropControl path={path} prop='csv' label='CSV' type='textarea' />
 		<Misc.SubmitButton url='/credit' path={path} once>Submit</Misc.SubmitButton>
 	</Misc.Card>);
 };

--- a/src/js/components/GiftAidForm.jsx
+++ b/src/js/components/GiftAidForm.jsx
@@ -4,7 +4,7 @@ import { FormGroup } from 'reactstrap';
 
 import DataStore from '../base/plumbing/DataStore';
 
-import Misc from '../base/components/Misc';
+import PropControl from '../base/components/PropControl';
 
 const giftAidTaxpayerLabel = 'I confirm that I am a UK taxpayer and I understand that if I pay less Income Tax and/or Capital Gains Tax in the current tax year than the amount of Gift Aid claimed on all my donations it is my responsibility to pay the difference.';
 const giftAidOwnMoneyLabel = 'This is my own money. I am not paying in donations made by a third party e.g. money collected at an event, in the pub, a company donation or a donation from a friend or family member.';
@@ -18,20 +18,20 @@ const GiftAidForm = ({ formPath }) => {
 	const giftAidChecks = giftAid ? (
 		<FormGroup>
 			<p>Please tick all the following to confirm your donation is eligible for Gift Aid.</p>
-			<Misc.PropControl prop='giftAidTaxpayer' label={giftAidTaxpayerLabel} path={formPath} type='checkbox' />
-			<Misc.PropControl prop='giftAidOwnMoney' label={giftAidOwnMoneyLabel} path={formPath} type='checkbox' />
-			<Misc.PropControl prop='giftAidNoCompensation' label={giftAidNoCompensationLabel} path={formPath} type='checkbox' />
+			<PropControl prop='giftAidTaxpayer' label={giftAidTaxpayerLabel} path={formPath} type='checkbox' />
+			<PropControl prop='giftAidOwnMoney' label={giftAidOwnMoneyLabel} path={formPath} type='checkbox' />
+			<PropControl prop='giftAidNoCompensation' label={giftAidNoCompensationLabel} path={formPath} type='checkbox' />
 			<p>Please provide the following details to enable your selected charity to process Gift Aid.</p>
-			<Misc.PropControl prop='name' label='Name' placeholder='Enter your name' path={formPath} type='text' />
-			<Misc.PropControl prop='address' label='Address' placeholder='Enter your address' path={formPath} type='address' />
-			<Misc.PropControl prop='postcode' label='Postcode' placeholder='Enter your postcode' path={formPath} type='postcode' />
+			<PropControl prop='name' label='Name' placeholder='Enter your name' path={formPath} type='text' />
+			<PropControl prop='address' label='Address' placeholder='Enter your address' path={formPath} type='address' />
+			<PropControl prop='postcode' label='Postcode' placeholder='Enter your postcode' path={formPath} type='postcode' />
 			<small>I understand that my name and address may be shared with the charity for processing Gift Aid.</small>
 		</FormGroup>
 	) : '';
 
 	return (
 		<div className='col-xs-12 gift-aid'>
-			<Misc.PropControl prop='giftAid' label='Yes, add Gift Aid' path={formPath} type='checkbox' />
+			<PropControl prop='giftAid' label='Yes, add Gift Aid' path={formPath} type='checkbox' />
 			{ giftAidChecks }
 			<small><a target='_blank' href='https://www.gov.uk/donating-to-charity/gift-aid'>
 				Find out more about Gift Aid

--- a/src/js/components/ImpactCalculator.jsx
+++ b/src/js/components/ImpactCalculator.jsx
@@ -21,7 +21,7 @@ import Project from '../data/charity/Project';
 import Output from '../data/charity/Output';
 import Money from '../base/data/Money';
 
-import Misc from '../base/components/Misc';
+import PropControl from '../base/components/PropControl';
 import { impactCalc } from './ImpactWidgetry';
 import { assert } from '../base/utils/assert';
 
@@ -112,7 +112,7 @@ class ImpactCalculator extends Component {
 		return (
 			<div className='donation-impact std-border std-padding std-box-shadow '>
 				<button onClick={donationDown} className='donation-down'>-</button>
-				<Misc.PropControl type='Money' prop='amount' path={formPath} changeCurrency={false} rawValue={null}/>
+				<PropControl type='Money' prop='amount' path={formPath} changeCurrency={false} rawValue={null}/>
 				<button onClick={donationUp} className='donation-up'>+</button>
 				<div className='will-fund div-section-larger-text'>can fund</div>
 				<DonationOutput impact={impact} charity={charity} />

--- a/src/js/components/RegisterPage.jsx
+++ b/src/js/components/RegisterPage.jsx
@@ -20,6 +20,7 @@ import Ticket from '../data/charity/Ticket';
 import FundRaiser from '../data/charity/FundRaiser';
 
 import Misc from '../base/components/Misc';
+import PropControl from '../base/components/PropControl';
 import { LoginWidgetEmbed } from '../base/components/LoginWidget';
 import Wizard, { WizardStage } from '../base/components/WizardProgressWidget';
 import PaymentWidget from '../base/components/PaymentWidget';
@@ -355,13 +356,13 @@ const AttendeeDetails = ({i, ticket, path, ticket0}) => {
 			</center>
 			<hr />
 			<div className='AttendeeDetails'>
-				<Misc.PropControl type='text' item={ticket} path={path} prop='attendeeName' label={`${noun} Name`} />
-				<Misc.PropControl type='text' item={ticket} path={path} prop='attendeeEmail' label='Email' />
-				{ i!==0? <Misc.PropControl type='checkbox' path={path} prop='sameAsFirst' label='Same address and team as first person' /> : null}
+				<PropControl type='text' item={ticket} path={path} prop='attendeeName' label={`${noun} Name`} />
+				<PropControl type='text' item={ticket} path={path} prop='attendeeEmail' label='Email' />
+				{ i!==0? <PropControl type='checkbox' path={path} prop='sameAsFirst' label='Same address and team as first person' /> : null}
 				{ sameAsFirst? null :
 					<div>
-						<Misc.PropControl type='textarea' path={path} prop='attendeeAddress' label='Address' />
-						<Misc.PropControl type='text' item={ticket} path={path} prop='emergencyContact' label='Emergency contact phone number' />
+						<PropControl type='textarea' path={path} prop='attendeeAddress' label='Address' />
+						<PropControl type='text' item={ticket} path={path} prop='emergencyContact' label='Emergency contact phone number' />
 						<TeamControl ticket={ticket} path={path} />
 					</div>
 				}
@@ -381,9 +382,9 @@ const TeamControl = ({ticket, path}) => {
 	}
 
 	return (<Misc.Col2>
-		<Misc.PropControl type='text' item={ticket} path={path} prop='team' label='Join Team (optional)'
+		<PropControl type='text' item={ticket} path={path} prop='team' label='Join Team (optional)'
 			help='Families or colleagues can fundraise as a team, with a Team Page here.' />
-		<Misc.PropControl type='text' item={ticket} path={path} prop='team' label='Create Team (optional)' />
+		<PropControl type='text' item={ticket} path={path} prop='team' label='Create Team (optional)' />
 	</Misc.Col2>);
 };
 
@@ -417,7 +418,7 @@ const CharityChoiceTab = ({basket}) => {
 			<p>
 				Please choose a charity to support.
 			</p>
-			<Misc.PropControl label='My Charity' item={basket} path={bpath} prop='charityId' />
+			<PropControl label='My Charity' item={basket} path={bpath} prop='charityId' />
 		</div>
 		<SearchResults results={results} query={charityId} recommended={ ! charityId}
 			onPick={onPick} CTA={PickCTA} tabs={false} download={false} loading={ ! pvCharities.resolved} />
@@ -484,10 +485,10 @@ const CheckoutTab = ({basket, event, stagePath}) => {
 	// 	basket.tip = new Money({value:1});
 	// }
 	// 		<div className='padded-block'>
-	// 			<Misc.PropControl type='checkbox' path={bpath} item={basket} prop='hasTip'
+	// 			<PropControl type='checkbox' path={bpath} item={basket} prop='hasTip'
 	// 				label={`Include a tip to cover SoGive's operating costs?`} />
 	// 			{basket.hasTip ? (
-	// 				<Misc.PropControl type='Money' path={bpath} item={basket} prop='tip' label='Tip amount' />
+	// 				<PropControl type='Money' path={bpath} item={basket} prop='tip' label='Tip amount' />
 	// 			) : ''}
 	// 		</div>
 

--- a/src/js/components/SearchPage.jsx
+++ b/src/js/components/SearchPage.jsx
@@ -2,14 +2,7 @@
 import React from 'react';
 import _ from 'lodash';
 // import {Button, Form, FormGroup, FormControl, Glyphicon, InputGroup} from 'react-bootstrap';
-import {
-    Form,
-    FormGroup,
-    Input,
-    InputGroup,
-    InputGroupAddon,
-    Button,
-} from "reactstrap";
+import { Form, Button } from "reactstrap";
 import { encURI, modifyHash, stopEvent } from "../base/utils/miscutils";
 
 import Login from "../base/youagain";
@@ -21,10 +14,10 @@ import NGO from "../data/charity/NGO2";
 import Project from "../data/charity/Project";
 import Output from "../data/charity/Output";
 import Misc from "../base/components/Misc";
+import PropControl from '../base/components/PropControl';
 import { impactCalc } from "./ImpactWidgetry";
 import C from "../C";
 import { getId } from "../base/data/DataClass";
-import PropControl from "../base/components/PropControl";
 import { LearnAboutRatings } from "./LearnAboutRatings";
 import { DonateButton } from './DonationWizard';
 import { RatingBadge } from "./CharityPage";
@@ -88,7 +81,7 @@ export default SearchPage;
 const FeaturedCharities = () => null;
 
 /**
- * TODO change into a Misc.PropControl??
+ * TODO change into a PropControl??
  */
 const SearchForm = ({ q, status }) => {
     let rawq = getValue([...PATH, "rawq"]);
@@ -261,32 +254,32 @@ const SuggestCharityForm = () => {
                 registering for an event, you can go ahead - enter "TBD" and you
                 can come back and set the charity later.
             </p>
-            <Misc.PropControl
+            <PropControl
                 path={fpath}
                 prop="charityName"
                 label="Name of charity"
             />
-            <Misc.PropControl
+            <PropControl
                 path={fpath}
                 prop="website"
                 label="Charity website"
             />
-            <Misc.PropControl
+            <PropControl
                 path={fpath}
                 prop="facebook"
                 label="Charity Facebook page (if applicable)"
             />
-            <Misc.PropControl
+            <PropControl
                 path={fpath}
                 prop="contactEmail"
                 label="Contact email for charity"
             />
-            <Misc.PropControl
+            <PropControl
                 path={fpath}
                 prop="contactPhone"
                 label="Contact phone number for charity"
             />
-            <Misc.PropControl path={fpath} prop="email" label="Your email" />
+            <PropControl path={fpath} prop="email" label="Your email" />
             <Misc.SubmitButton
                 url={profilerEndpoint}
                 path={fpath}

--- a/src/js/components/editor/EditCharityPage.jsx
+++ b/src/js/components/editor/EditCharityPage.jsx
@@ -14,6 +14,7 @@ import NGO from '../../data/charity/NGO2';
 import Project from '../../data/charity/Project';
 import Money from '../../base/data/Money';
 import Misc from '../../base/components/Misc';
+import PropControl from '../../base/components/PropControl';
 import Roles from '../../base/Roles';
 import {LoginLink} from '../../base/components/LoginWidget';
 import Crud, { getDataItem } from '../../base/plumbing/Crud'; //publish
@@ -416,8 +417,8 @@ const ProjectInputEditor = ({charity, project, input}) => {
 	return (<tr>
 		<td>{iname}</td>
 		<td>
-			{ isOverall || input.name==="projectCosts"? null : <Misc.PropControl label={'Manual entry for '+iname} type="checkbox" prop="manualEntry" path={widgetPath} /> }
-			<Misc.PropControl type="Money" prop={ii} path={inputsPath} item={project.inputs} readOnly={readonly} />
+			{ isOverall || input.name==="projectCosts"? null : <PropControl label={'Manual entry for '+iname} type="checkbox" prop="manualEntry" path={widgetPath} /> }
+			<PropControl type="Money" prop={ii} path={inputsPath} item={project.inputs} readOnly={readonly} />
 		</td>
 	</tr>);
 };
@@ -438,19 +439,19 @@ const ProjectOutputEditor = ({charity, project, output}) => {
 	let cpb = output? output.costPerBeneficiary : null;
 	let cpbraw = output? NGO.costPerBeneficiaryCalc({charity:charity, project:project, output:output}) : null;
 	return (<tr>
-		<td><Misc.PropControl prop="name" path={inputPath} item={output} /></td>
-		<td><Misc.PropControl prop="number" type="number" path={inputPath} item={output} /></td>
+		<td><PropControl prop="name" path={inputPath} item={output} /></td>
+		<td><PropControl prop="number" type="number" path={inputPath} item={output} /></td>
 		<td>
-			<Misc.PropControl prop="costPerBeneficiary" type="Money" path={inputPath} item={output} />
+			<PropControl prop="costPerBeneficiary" type="Money" path={inputPath} item={output} />
 			<small>Calculated: <Misc.Money amount={cpbraw} /></small>
 		</td>
 		<td>
-			<Misc.PropControl prop="confidence" type="select" options={CONFIDENCE_VALUES.values}
+			<PropControl prop="confidence" type="select" options={CONFIDENCE_VALUES.values}
 				defaultValue={CONFIDENCE_VALUES.medium} path={inputPath} item={output}
 			/>
 		</td>
 		<td>
-			<Misc.PropControl prop="description" type="textarea"
+			<PropControl prop="description" type="textarea"
 				path={inputPath} item={output}
 			/>
 		</td>
@@ -489,7 +490,7 @@ const EditField2 = ({item, field, type, help, label, path, parentItem, userFilte
 	return (
 		<div>
 			<Misc.Col2>
-				<Misc.PropControl label={label || field} type={type} prop={field}
+				<PropControl label={label || field} type={type} prop={field}
 					path={path} item={item}
 					tooltip={help}
 					{ ...other}
@@ -550,7 +551,7 @@ const MetaEditorItem = ({meta, itemField, metaField, metaPath, icon, title, type
 	return (
 		<div className="MetaEditorItem">
 			{ricon}
-			<Misc.PropControl label={title} prop={metaField}
+			<PropControl label={title} prop={metaField}
 				path={metaPath}
 				item={meta} type={type}
 				saveFn={saveFn}

--- a/src/js/components/editor/EditFundRaiserPage.jsx
+++ b/src/js/components/editor/EditFundRaiserPage.jsx
@@ -8,6 +8,7 @@ import DataStore from '../../base/plumbing/DataStore';
 import C from '../../C';
 
 import Misc from '../../base/components/Misc';
+import PropControl from '../../base/components/PropControl';
 import FundRaiser from '../../data/charity/FundRaiser';
 import { DonateButton } from '../DonationWizard';
 import ShareWidget, {ShareLink, canWrite} from '../../base/components/ShareWidget';
@@ -70,21 +71,21 @@ const FundRaiserEditor = ({id}) => {
 					<ShareLink item={item} />
 					<ShareWidget item={item} />
 				</small></p>
-				<Misc.PropControl path={path} prop='name' item={item} label='Fundraiser Name' />
-				<Misc.PropControl path={path} prop='img' label='Fundraiser Photo' type='imgUpload' />
-				<Misc.PropControl path={path} prop='description' item={item} label='Description' />
-				<Misc.PropControl path={path} prop='charityId' item={item} label='Charity' />
-				<Misc.PropControl path={path} prop='userTarget' item={item} label='Fixed £ Target' type='Money'
+				<PropControl path={path} prop='name' item={item} label='Fundraiser Name' />
+				<PropControl path={path} prop='img' label='Fundraiser Photo' type='imgUpload' />
+				<PropControl path={path} prop='description' item={item} label='Description' />
+				<PropControl path={path} prop='charityId' item={item} label='Charity' />
+				<PropControl path={path} prop='userTarget' item={item} label='Fixed £ Target' type='Money'
 					placeholder='Leave blank for an automatic target (recommended). Set to -1 to switch off the targets.'
 				/>
 
-				<Misc.PropControl path={path} prop='donated' item={item} label='DEBUG: Set donated' type='Money' />
-				<Misc.PropControl path={path} prop='donationCount' item={item} label='DEBUG: Set donor count' type='number' />
+				<PropControl path={path} prop='donated' item={item} label='DEBUG: Set donated' type='Money' />
+				<PropControl path={path} prop='donationCount' item={item} label='DEBUG: Set donor count' type='number' />
 
-				<Misc.PropControl path={peepPath} prop='name' label='Your Name' />
-				<Misc.PropControl path={peepPath} prop='img' label='Your Photo' type='imgUpload' />
-				<Misc.PropControl path={peepPath} prop='description' label='About You' type='textarea' />
-				<Misc.PropControl path={path} prop='story' item={item} label='Your Story' type='textarea' />
+				<PropControl path={peepPath} prop='name' label='Your Name' />
+				<PropControl path={peepPath} prop='img' label='Your Photo' type='imgUpload' />
+				<PropControl path={peepPath} prop='description' label='About You' type='textarea' />
+				<PropControl path={path} prop='story' item={item} label='Your Story' type='textarea' />
 				<hr />
 				<p className='CTA'><a href={'#fundraiser/'+encURI(id)}>Go to Your FundRaiser Page</a></p>
 

--- a/src/js/components/editor/EditorDashboardPage.jsx
+++ b/src/js/components/editor/EditorDashboardPage.jsx
@@ -12,7 +12,8 @@ import ActionMan from '../../plumbing/ActionMan';
 import { LoginLink } from '../../base/components/LoginWidget';
 // import ChartWidget from './../base/components/ChartWidget';
 import Misc from '../../base/components/Misc';
-import {notifyUser} from '../../base/plumbing/Messaging';
+import PropControl from '../../base/components/PropControl';
+import { notifyUser } from '../../base/plumbing/Messaging';
 import ShareWidget, {AccessDenied} from '../../base/components/ShareWidget';
 
 
@@ -43,7 +44,7 @@ const AddCharityWidget = () => {
 		<div className='alert alert-warning'>
 			ALWAYS <a href={'#search?status=ALL_BAR_TRASH'}>search</a> first to check the charity isn't already in the database.
 			Otherwise we will have ugly merge problems.</div>
-		<Misc.PropControl prop='name' label='Name' path={['widget','AddCharityWidget', 'form']} />
+		<PropControl prop='name' label='Name' path={['widget','AddCharityWidget', 'form']} />
 		<button className='btn btn-warning' onClick={() => ActionMan.addCharity()}>Add Charity</button>
 	</Misc.Card>);
 };
@@ -58,7 +59,7 @@ const doAddEditor = function() {
 const AddEditorWidget = () => {
 	return (<Misc.Card title='Add a new Editor' >
 		<p>Use this form to add someone to the editors team. Anyone can make edits, but only approved editors can publish them.</p>
-		<Misc.PropControl prop='email' label='Email' path={['widget','AddEditorWidget', 'form']} />
+		<PropControl prop='email' label='Email' path={['widget','AddEditorWidget', 'form']} />
 		<button className='btn btn-warning' onClick={doAddEditor}>Add Them</button>
 	</Misc.Card>);
 };
@@ -108,7 +109,7 @@ const ImportEditorialsWidget = () => {
 			<li>In the Docs menu, select <b>File</b> &gt; <b>Publish to the web</b>, and click <b>[Publish]</b>.</li>
 			<li>Copy the link from that dialog.</li>
 		</ol>
-		<Misc.PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label="Published link: (should end in '/pub')" path={['widget','ImportEditorialsWidget', 'form']} />
+		<PropControl prop='publishedEditorialsDoc' name='editorialsUrl' label="Published link: (should end in '/pub')" path={['widget','ImportEditorialsWidget', 'form']} />
 		<button className='btn btn-warning' onClick={doImportEditorials} name='importEditorials'>Import Editorials</button>
 	</Misc.Card>);
 };


### PR DESCRIPTION
- Cleaning up Webpack configs exposed a dependency loop between Misc.jsx and PropControl.jsx
- This is resolved by removing Misc.PropControl and Misc.FormControl from Misc.jsx in the wwappbase.js repo
- Before doing this, projects using wwappbase.js should stop invoking Misc.PropControl